### PR TITLE
Se arregla bug en combo OS en pop-up de detalle de turno

### DIFF
--- a/settings.py.bak
+++ b/settings.py.bak
@@ -134,6 +134,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
+    'rest_framework',
     'contenidos',
     'managers',
     'sala',
@@ -145,6 +146,15 @@ INSTALLED_APPS = (
     'estudio',
     "comprobante",
 )
+
+
+REST_FRAMEWORK = {
+    #'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAdminUser',),
+    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.AllowAny',),
+    #'PAGINATE_BY': 30
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',)
+}
+
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 

--- a/static/templates/js/turno.js
+++ b/static/templates/js/turno.js
@@ -245,9 +245,8 @@ function getEdit(event) {
       modal.find("#popup-observacion_turno")
            .text(data.observacion)
            .val(data.observacion);
-
       modal.find("#current-turno-id").val(data.id);
-      modal.find("#id-obra-social option[value='" + data.obra_social + "']").attr('selected', 'selected');
+      modal.find("#id-obra-social").val(data.obra_social);
       modal.find("#id-obra-social").trigger("chosen:updated");
       modal.find("#popup-creado-por").text(data.creado_por);
     },


### PR DESCRIPTION
@jiaguilera se arreglo un error con el combo de Obra social en el pop-up de detalle de turno cuando buscas un turno. Estaba mostrando otra obra social que no era la elegida.