### PR TITLE
Add owl-carousel as a npm deps

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "static/templates/bower_components"
+  "directory": "static/templates/bower_components",
+  "registry": "https://registry.bower.io"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs
 node_modules/
 static/templates/media_files
 static/templates/bower_components/
+static/templates/npm_deps/
 .idea
 .vscode
 ENV/

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "magnific-popup": "~1.1.0",
     "isotope": "~3.0.1",
     "hover": "~2.0.2",
-    "owl-carousel": "~1.3.2",
     "parallax": "~2.1.3",
     "vide": "~0.5.0",
     "waypoints": "~4.0.1",

--- a/contenidos/templates/home/base.html
+++ b/contenidos/templates/home/base.html
@@ -41,8 +41,8 @@
 		<link href="{% static 'bower_components/magnific-popup/dist/magnific-popup.css' %}" rel="stylesheet">
 		<link href="{% static 'template/rs-plugin/css/settings.css' %}" rel="stylesheet">
 		<link href="{% static 'template/css/animations.css' %}" rel="stylesheet">
-		<link href="{% static 'bower_components/owl-carousel/owl-carousel/owl.carousel.css' %}" rel="stylesheet">
-		<link href="{% static 'bower_components/owl-carousel/owl-carousel/owl.transitions.css' %}" rel="stylesheet">
+		<link href="{% static 'npm_deps/owl-carousel/owl-carousel/owl.carousel.css' %}" rel="stylesheet">
+		<link href="{% static 'npm_deps/owl-carousel/owl-carousel/owl.transitions.css' %}" rel="stylesheet">
 		<link href="{% static 'bower_components/hover/css/hover-min.css' %}" rel="stylesheet">
 
 		<!-- The Project's core CSS file -->
@@ -468,7 +468,7 @@
 		<!-- Background Video -->
 		<script src="{% static 'bower_components/vide/dist/jquery.vide.js' %}"></script>
 		<!-- Owl carousel javascript -->
-		<script type="text/javascript" src="{% static 'bower_components/owl-carousel/owl-carousel/owl.carousel.js' %}"></script>
+		<script type="text/javascript" src="{% static 'npm_deps/owl-carousel/owl-carousel/owl.carousel.js' %}"></script>
 		<!-- SmoothScroll javascript -->
 		<script type="text/javascript" src="{% static 'bower_components/jquery.browser/dist/jquery.browser.js' %}"></script>
 		<script type="text/javascript" src="{% static 'bower_components/smoothscroll-for-websites/SmoothScroll.js' %}"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "cedir",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bower": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
+      "dev": true
+    },
+    "owl-carousel": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/owl-carousel/-/owl-carousel-1.0.0.tgz",
+      "integrity": "sha512-xgOxxUqpSPM0dopWkcMri9MoGv8TrEDAnsc+6OYuHhO2x3YpsEKDW2fJomPDOA6KkSTa3utLvgP+irVwAXSGog=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "scripts": {
     "postinstall": "bower install"
+  },
+  "dependencies": {
+    "owl-carousel": "^1.0.0"
   }
 }


### PR DESCRIPTION
Moving the package owl-carousel from ./node_modules to ./static/templates/npm_deps manually, is required for this to work