### PR TITLE
pyafipws

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,3 @@
+Para la pylib de la afip, pip clonará el repo correspondiente desde git. Solo instalamos las dependencias necesarias para los modulos que vamos a usar, para no inflar las dependencias.
+Para poder usarla, es necesario agregar al directorio de trabajo un certificado y su clave privada. En entornos de desarrollo será un certificado emitido para la api de homologacion y en produccion será uno de la api de produccion de producción.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# CEDIR WEB
+
+### AFIP
+
 Para la pylib de la afip, pip clonará el repo correspondiente desde git. Solo instalamos las dependencias necesarias para los modulos que vamos a usar, para no inflar las dependencias.
 Para poder usarla, es necesario agregar al directorio de trabajo un certificado y su clave privada. En entornos de desarrollo será un certificado emitido para la api de homologacion y en produccion será uno de la api de produccion de producción.
+
+Links importantes:
+
+https://www.pyafipws.com.ar/
+
+https://github.com/reingart/pyafipws.git
+
+https://groups.google.com/forum/#!forum/pyafipws
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,11 @@ django-filter==1.1.0
 djangorestframework==3.4.6
 django-cors-headers==1.3.1
 
+# AFIP
+m2crypto
+pysimplesoap==1.8.14
+httplib2==0.9.2
+git+https://github.com/reingart/pyafipws.git
+
 # testing or dev tools (TODO: should go on a different file)
 mock==1.0.1                    # Mocking and patching library for testing


### PR DESCRIPTION
Resulta que leyendo por ahí descubrí que podés hacer este truquito de decirle a pip que clone desde el master de un repo. Lo interesante es que no corre los requirements del repo, así que nos permite instalar manualmente las dependencias que necesitemos. O sea, actualizaciones fáciles pero sin inflar dependencias.
La contra que veo es que si esta gente pushea a su master algo que rompe, nos rompe a nosotros la proxima vez que corramos el pip install. Pero, eso lo veo poco probable (no creo hagamos anda raro que no este cubierto por sus tests) y de todas formas si ocurriera, lo solucionamos forkeandole el repo y cambiando la url del requirements.txt
Me parece la solución ideal.

Lo testié y con ese requirements.txt la AFIP me autentica y me emite comprobantes.

¿Qué te parece?