### PR TITLE
FCE en informe de comprobantes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ static/templates/npm_deps/
 ENV/
 certificados/
 
-informe_ejemplo.xlsx
+informes_comprobantes_ejemplos/

--- a/comprobante/calculador_informe.py
+++ b/comprobante/calculador_informe.py
@@ -2,31 +2,25 @@ from abc import abstractproperty
 from decimal import Decimal
 
 from medico.calculo_honorarios import CalculadorHonorariosInformeContadora
-from comprobante.models import LineaDeComprobante
-
-FACTURA = 1
-LIQUIDACION = 2
-NOTA_DE_DEBITO = 3
-NOTA_DE_CREDITO = 4
-FACTURA_ELECTRONICA_MIPYME = 5
-NOTA_DE_DEBITO_ELECTRONICA_MIPYME = 6
-NOTA_DE_CREDITO_ELECTRONICA_MIPYME = 7
-
+from comprobante.models import LineaDeComprobante, ID_TIPO_COMPROBANTE_FACTURA, \
+    ID_TIPO_COMPROBANTE_LIQUIDACION, ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO, \
+    ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO, ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA, \
+    ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA, ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA
 
 def calculador_informe_factory(comprobante):
-    if comprobante.tipo_comprobante.id == FACTURA:
+    if comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_FACTURA:
         return CalculadorInformeFactura(comprobante)
-    elif comprobante.tipo_comprobante.id == NOTA_DE_DEBITO:
+    elif comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_LIQUIDACION:
         return CalculadorInformeFactura(comprobante)
-    elif comprobante.tipo_comprobante.id == NOTA_DE_CREDITO:
+    elif comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO:
+        return CalculadorInformeFactura(comprobante)
+    elif comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO:
         return CalculadorInformeNotaCredito(comprobante)
-    elif comprobante.tipo_comprobante.id == LIQUIDACION:
+    elif comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA:
         return CalculadorInformeFactura(comprobante)
-    elif comprobante.tipo_comprobante.id == FACTURA_ELECTRONICA_MIPYME:
+    elif comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA:
         return CalculadorInformeFactura(comprobante)
-    elif comprobante.tipo_comprobante.id == NOTA_DE_DEBITO_ELECTRONICA_MIPYME:
-        return CalculadorInformeFactura(comprobante)
-    elif comprobante.tipo_comprobante.id == NOTA_DE_CREDITO_ELECTRONICA_MIPYME:
+    elif comprobante.tipo_comprobante.id == ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA:
         return CalculadorInformeNotaCredito(comprobante)
     else:
         raise Exception(comprobante.tipo_comprobante.nombre)

--- a/comprobante/calculador_informe.py
+++ b/comprobante/calculador_informe.py
@@ -4,16 +4,30 @@ from decimal import Decimal
 from medico.calculo_honorarios import CalculadorHonorariosInformeContadora
 from comprobante.models import LineaDeComprobante
 
+FACTURA = 1
+LIQUIDACION = 2
+NOTA_DE_DEBITO = 3
+NOTA_DE_CREDITO = 4
+FACTURA_ELECTRONICA_MIPYME = 5
+NOTA_DE_DEBITO_ELECTRONICA_MIPYME = 6
+NOTA_DE_CREDITO_ELECTRONICA_MIPYME = 7
+
 
 def calculador_informe_factory(comprobante):
-    if comprobante.tipo_comprobante.nombre in "Factura":
+    if comprobante.tipo_comprobante.id == FACTURA:
         return CalculadorInformeFactura(comprobante)
-    elif comprobante.tipo_comprobante.nombre == "Nota De Debito":
-        return CalculadorInformeNotaDebito(comprobante)
-    elif comprobante.tipo_comprobante.nombre == "Nota De Credito":
+    elif comprobante.tipo_comprobante.id == NOTA_DE_DEBITO:
+        return CalculadorInformeFactura(comprobante)
+    elif comprobante.tipo_comprobante.id == NOTA_DE_CREDITO:
         return CalculadorInformeNotaCredito(comprobante)
-    elif comprobante.tipo_comprobante.nombre == "Liquidacion":
-        return CalculadorInformeLiquidacion(comprobante)
+    elif comprobante.tipo_comprobante.id == LIQUIDACION:
+        return CalculadorInformeFactura(comprobante)
+    elif comprobante.tipo_comprobante.id == FACTURA_ELECTRONICA_MIPYME:
+        return CalculadorInformeFactura(comprobante)
+    elif comprobante.tipo_comprobante.id == NOTA_DE_DEBITO_ELECTRONICA_MIPYME:
+        return CalculadorInformeFactura(comprobante)
+    elif comprobante.tipo_comprobante.id == NOTA_DE_CREDITO_ELECTRONICA_MIPYME:
+        return CalculadorInformeNotaCredito(comprobante)
     else:
         raise Exception(comprobante.tipo_comprobante.nombre)
 
@@ -181,23 +195,14 @@ class CalculadorInformeFactura(CalculadorInforme):
             return Decimal("0.00")
         return sum([aux(estudio) * (1 - estudio.retencion_impositiva) for estudio in self.estudios])
 
-
-class CalculadorInformeNotaDebito(CalculadorInformeFactura):
-    """
-    Las notas de debito tienen en principio las mismas reglas que una factura pero definimos esta clase por generalidad
-    y por si apareciera una regla especifica para mismas.
-    """
-    pass
-
-
 class CalculadorInformeNotaCredito(CalculadorInforme):
     """
     Las notas de credito tienen la misma logica que las facturas pero los valores se muestran en negativo.
-    Por lo tanto, definimos esta clase que aplica la logica de un calculador de facturas pero devuelve el opuesto.
+    Por lo tanto, definimos esta clase que aplica la logica de un calculador de facturas pero devuelve el valor negativo.
     """
     def __init__(self, comprobante):
         self.comprobante = comprobante
-        self.calculador_aux = CalculadorInformeNotaDebito(comprobante)
+        self.calculador_aux = CalculadorInformeFactura(comprobante)
 
     @property
     def total_facturado(self):
@@ -250,11 +255,3 @@ class CalculadorInformeNotaCredito(CalculadorInforme):
     @property
     def total_material_especifico(self):
         return Decimal("-1") * self.calculador_aux.total_material_especifico
-
-
-class CalculadorInformeLiquidacion(CalculadorInformeFactura):
-    """
-    Las liquidaciones tienen en principio las mismas reglas que una factura pero definimos esta clase por generalidad
-    y por si apareciera una regla especifica para mismas.
-    """
-    pass

--- a/comprobante/models.py
+++ b/comprobante/models.py
@@ -1,7 +1,13 @@
 from datetime import timedelta
 from django.db import models
 
+ID_TIPO_COMPROBANTE_FACTURA = 1
+ID_TIPO_COMPROBANTE_LIQUIDACION = 2
+ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO = 3
+ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO = 4
 ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA = 5
+ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA = 6
+ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA = 7
 
 class TipoComprobante(models.Model):
     nombre = models.CharField(max_length=128, db_column=u'tipoComprobante')
@@ -58,8 +64,22 @@ class Comprobante(models.Model):
     @property
     def codigo_afip(self):
         conversion = {
-            'A': {1: 1, 3: 2, 4: 3, 5: 201, 6: 202, 7: 203},
-            'B': {1: 6, 3: 7, 4: 8, 5: 206, 6: 207, 7: 208}
+            'A': {
+                ID_TIPO_COMPROBANTE_FACTURA: 1,
+                ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO: 2,
+                ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO: 3,
+                ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA: 201,
+                ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA: 202,
+                ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA: 203
+            },
+            'B': {
+                ID_TIPO_COMPROBANTE_FACTURA: 6,
+                ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO: 7,
+                ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO: 8,
+                ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA: 206,
+                ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA: 207,
+                ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA: 208
+            }
         }
         return conversion[self.sub_tipo][self.tipo_comprobante.id]
 

--- a/comprobante/tests_informe_contadora.py
+++ b/comprobante/tests_informe_contadora.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal
+import json
 
 from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User
+
 from comprobante.models import Comprobante, TipoComprobante
-from comprobante.calculador_informe import calculador_informe_factory, CalculadorInformeFactura, CalculadorInformeNotaCredito, CalculadorInformeNotaDebito
+from comprobante.calculador_informe import calculador_informe_factory, CalculadorInformeFactura, CalculadorInformeNotaCredito
 
 
 class TestHerramientaInformeComprobantesContadora(TestCase):
@@ -14,7 +18,7 @@ class TestHerramientaInformeComprobantesContadora(TestCase):
                 "presentaciones.json", "obras_sociales.json", "estudios.json", "medicos.json", "pacientes.json"]
     def setUp(self):
         self.lineas_informe = [calculador_informe_factory(c) for c in Comprobante.objects.all()]
- 
+
     def test_informe_propiedades_definidas(self):
         for linea in self.lineas_informe:
             linea.total_facturado
@@ -37,13 +41,16 @@ class CreateInformeFactoryTest(TestCase):
     Estos tests se aseguran de que el factory cree el calculador correcto para
     cada tipo de comprobante.
     """
+    fixtures = ["comprobantes.json"]
+
     def setUp(self):
-        self.tipo_comprobante_factura = TipoComprobante.objects.create(
-            nombre='Factura')
-        self.tipo_comprobante_nota_debito = TipoComprobante.objects.create(
-            nombre='Nota De Debito')
-        self.tipo_comprobante_nota_credito = TipoComprobante.objects.create(
-            nombre='Nota De Credito')
+        self.tipo_comprobante_factura = TipoComprobante.objects.get(pk=1)
+        self.tipo_comprobante_liquidacion = TipoComprobante.objects.get(pk=2)
+        self.tipo_comprobante_nota_debito = TipoComprobante.objects.get(pk=3)
+        self.tipo_comprobante_nota_credito = TipoComprobante.objects.get(pk=4)
+        self.tipo_comprobante_factura_electronica = TipoComprobante.objects.get(pk=5)
+        self.tipo_comprobante_nota_debito_electronica = TipoComprobante.objects.get(pk=6)
+        self.tipo_comprobante_nota_credito_electronica = TipoComprobante.objects.get(pk=7)
 
     def test_factory_factura(self):
         comprobante = Comprobante(
@@ -56,9 +63,29 @@ class CreateInformeFactoryTest(TestCase):
             tipo_comprobante=self.tipo_comprobante_nota_debito)
         instance_created = calculador_informe_factory(comprobante)
         self.assertTrue(isinstance(instance_created,
-                                   CalculadorInformeNotaDebito))
+                                   CalculadorInformeFactura))
 
     def test_factory_nota_credito(self):
+        comprobante = Comprobante(
+            tipo_comprobante=self.tipo_comprobante_nota_credito)
+        instance_created = calculador_informe_factory(comprobante)
+        self.assertTrue(isinstance(instance_created,
+                                   CalculadorInformeNotaCredito))
+
+    def test_factory_factura_de_credito_electronica(self):
+        comprobante = Comprobante(
+            tipo_comprobante=self.tipo_comprobante_factura)
+        instance_created = calculador_informe_factory(comprobante)
+        self.assertTrue(isinstance(instance_created, CalculadorInformeFactura))
+
+    def test_factory_nota_debito_electronica(self):
+        comprobante = Comprobante(
+            tipo_comprobante=self.tipo_comprobante_nota_debito)
+        instance_created = calculador_informe_factory(comprobante)
+        self.assertTrue(isinstance(instance_created,
+                                   CalculadorInformeFactura))
+
+    def test_factory_nota_credito_electronica(self):
         comprobante = Comprobante(
             tipo_comprobante=self.tipo_comprobante_nota_credito)
         instance_created = calculador_informe_factory(comprobante)
@@ -113,3 +140,19 @@ class TestCaluloRetencionImpositiva(TestCase):
         retencion_esperada = Decimal(
             "25.00") * presentacion.total_facturado / Decimal("100.00")
         self.assertEquals(calculador.retencion_impositiva, retencion_esperada)
+
+class TestEndpoint(TestCase):
+    fixtures = ["comprobantes.json", "practicas.json", "anestesistas.json",
+                "presentaciones.json", "obras_sociales.json", "estudios.json", "medicos.json", "pacientes.json"]
+
+    def test_endpoint_informe_comprobantes(self):
+        self.user = User.objects.create_user(username='test', password='test', is_superuser=True)
+        self.client = Client(HTTP_GET='localhost')
+        self.client.login(username='test', password='test')
+        response = self.client.get('/api/comprobantes/', {
+            "mes": 7,
+            "anio": 2012,
+        })
+        content = json.loads(response.content)
+        linea_informe = content[0]
+        self.assertIsInstance(linea_informe, dict)

--- a/comprobante/tests_informe_contadora.py
+++ b/comprobante/tests_informe_contadora.py
@@ -6,7 +6,10 @@ from django.test import TestCase
 from django.test import Client
 from django.contrib.auth.models import User
 
-from comprobante.models import Comprobante, TipoComprobante
+from comprobante.models import Comprobante, TipoComprobante, ID_TIPO_COMPROBANTE_FACTURA, \
+    ID_TIPO_COMPROBANTE_LIQUIDACION, ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO, \
+    ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO, ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA, \
+    ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA, ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA
 from comprobante.calculador_informe import calculador_informe_factory, CalculadorInformeFactura, CalculadorInformeNotaCredito
 
 
@@ -44,13 +47,13 @@ class CreateInformeFactoryTest(TestCase):
     fixtures = ["comprobantes.json"]
 
     def setUp(self):
-        self.tipo_comprobante_factura = TipoComprobante.objects.get(pk=1)
-        self.tipo_comprobante_liquidacion = TipoComprobante.objects.get(pk=2)
-        self.tipo_comprobante_nota_debito = TipoComprobante.objects.get(pk=3)
-        self.tipo_comprobante_nota_credito = TipoComprobante.objects.get(pk=4)
-        self.tipo_comprobante_factura_electronica = TipoComprobante.objects.get(pk=5)
-        self.tipo_comprobante_nota_debito_electronica = TipoComprobante.objects.get(pk=6)
-        self.tipo_comprobante_nota_credito_electronica = TipoComprobante.objects.get(pk=7)
+        self.tipo_comprobante_factura = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_FACTURA)
+        self.tipo_comprobante_liquidacion = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_LIQUIDACION)
+        self.tipo_comprobante_nota_debito = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO)
+        self.tipo_comprobante_nota_credito = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO)
+        self.tipo_comprobante_factura_electronica = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA)
+        self.tipo_comprobante_nota_debito_electronica = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA)
+        self.tipo_comprobante_nota_credito_electronica = TipoComprobante.objects.get(pk=ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA)
 
     def test_factory_factura(self):
         comprobante = Comprobante(

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ git+https://github.com/reingart/pyafipws.git
 mock==1.0.1                    # Mocking and patching library for testing
 pylint
 pylint-django==0.11.1
+xlrd # Tool informe contadora

--- a/scripts/tool_testear_afip_contra_webservice.py
+++ b/scripts/tool_testear_afip_contra_webservice.py
@@ -8,7 +8,6 @@ El script emite un comprobante de cada uno de los tipos validos que tenemos. (ex
 
 ATENCION: esto emite comprobantes contra la url y con los certificados configurados en settings.py
 O sea qe si lo corres en produccion, facturas en falso :)
-Tambien borra comprobantes de la DB para no tener colisiones de numero.
 
 Para correrlo contra el entorno de test, se necesitan las urls correctas y certificados de homologacion.
 Tener en cuenta que el servicio de homologacion se cae bastante.

--- a/scripts/tool_testear_herramienta_informes_contadora.py
+++ b/scripts/tool_testear_herramienta_informes_contadora.py
@@ -7,6 +7,11 @@
 #       Crea un informe con la herramienta
 #       Compara campo por campo e imprime en consola los que tengan una diferencia
 #
+# Llamarlo con:
+# $ python scripts/tool_testear_herramienta_informes_contadora.py path_a_informe_ejemplo.xlsx
+#
+# Los informes de ejemplo se encuentran en el mega, en una carpeta "informes_comproabntes_ejemplo"
+
 
 # Correccion del path para importar desde el directorio padre
 from __future__ import print_function


### PR DESCRIPTION
- Agregue soporte a los nuevos tipos de comprobante en la API de informe
de comprobantes
- Cambie el Factory para que use las IDs, como el resto del codigo.
- Elimine los herederos vacios de CalculadorInformeFactura. Parecia un
buen diseño cuando eran pocos, pero se volveria ilegible si tuvieramos 5
vacios ahora.
- Agregue algunas instrucciones en la tool para testear la API y una
libreria para leer excels que faltaba en el requirements.txt
- Agregue algunoos tests.