### PR TITLE
Fix afip dos decimales

### DIFF
--- a/comprobante/test_comprobantes_asociados.py
+++ b/comprobante/test_comprobantes_asociados.py
@@ -207,3 +207,12 @@ class TestComprobantesAsociados(TestCase):
             crear_comprobante_asociado(1, Decimal(100), '')
 
         assert cantidad_inicial == Comprobante.objects.count()
+
+    @patch('comprobante.comprobante_asociado.Afip')
+    def test_guarda_decimales_en_comprobante(self, afip_mock):
+        afip = afip_mock()
+        afip.consultar_proximo_numero.return_value = 11
+
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(200.52), '')
+
+        assert nuevo_comp.total_facturado == Decimal(200.52).quantize(Decimal(10)**-2)

--- a/comprobante/test_comprobantes_asociados.py
+++ b/comprobante/test_comprobantes_asociados.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from mock import patch
 from datetime import date
+from decimal import Decimal
 from comprobante.comprobante_asociado import crear_comprobante_asociado, TipoComprobanteAsociadoNoValidoException
 from comprobante.afip import AfipErrorRed, AfipErrorValidacion
 from comprobante.models import Comprobante, TipoComprobante, LineaDeComprobante, \
@@ -20,13 +21,13 @@ class TestComprobantesAsociados(TestCase):
 
         comp = Comprobante.objects.get(pk = 1)
 
-        nuevo_comp = crear_comprobante_asociado(1, 200, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(200), '')
 
         assert nuevo_comp.nombre_cliente == comp.nombre_cliente
         assert nuevo_comp.nro_cuit == comp.nro_cuit
         assert nuevo_comp.responsable == comp.responsable
         assert nuevo_comp.condicion_fiscal == comp.condicion_fiscal
-        assert nuevo_comp.total_facturado == 200
+        assert nuevo_comp.total_facturado == Decimal(200).quantize(Decimal(10)**-2)
         assert nuevo_comp.tipo_comprobante == TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO)
         assert nuevo_comp.nro_terminal == comp.nro_terminal
 
@@ -36,7 +37,7 @@ class TestComprobantesAsociados(TestCase):
         nuevo_comp.tipo_comprobante = TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_LIQUIDACION)
         nuevo_comp.save()
         with self.assertRaises(TipoComprobanteAsociadoNoValidoException):
-            crear_comprobante_asociado(1, 500, '')
+            crear_comprobante_asociado(1, Decimal(500), '')
 
     @patch('comprobante.comprobante_asociado.Afip')
     def test_genera_nota_de_credito_si_se_envia_una_nota_de_debito(self, afip_mock):
@@ -47,13 +48,13 @@ class TestComprobantesAsociados(TestCase):
         comp.tipo_comprobante = TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO)
         comp.save()
 
-        nuevo_comp = crear_comprobante_asociado(1, 300, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(300), '')
 
         assert nuevo_comp.nombre_cliente == comp.nombre_cliente
         assert nuevo_comp.nro_cuit == comp.nro_cuit
         assert nuevo_comp.responsable == comp.responsable
         assert nuevo_comp.condicion_fiscal == comp.condicion_fiscal
-        assert nuevo_comp.total_facturado == 300
+        assert nuevo_comp.total_facturado == Decimal(300).quantize(Decimal(10)**-2)
         assert nuevo_comp.tipo_comprobante == TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO)
         assert nuevo_comp.nro_terminal == comp.nro_terminal
     
@@ -65,13 +66,13 @@ class TestComprobantesAsociados(TestCase):
         comp = Comprobante.objects.get(pk = 1)
         comp.tipo_comprobante = TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO)
         comp.save()
-        nuevo_comp = crear_comprobante_asociado(1, 400, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(400), '')
 
         assert nuevo_comp.nombre_cliente == comp.nombre_cliente
         assert nuevo_comp.nro_cuit == comp.nro_cuit
         assert nuevo_comp.responsable == comp.responsable
         assert nuevo_comp.condicion_fiscal == comp.condicion_fiscal
-        assert nuevo_comp.total_facturado == 400
+        assert nuevo_comp.total_facturado == Decimal(400).quantize(Decimal(10)**-2)
         assert nuevo_comp.tipo_comprobante == TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO)
         assert nuevo_comp.nro_terminal == comp.nro_terminal
 
@@ -84,13 +85,13 @@ class TestComprobantesAsociados(TestCase):
         comp.tipo_comprobante = TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA)
         comp.save()
 
-        nuevo_comp = crear_comprobante_asociado(1, 200, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(200), '')
 
         assert nuevo_comp.nombre_cliente == comp.nombre_cliente
         assert nuevo_comp.nro_cuit == comp.nro_cuit
         assert nuevo_comp.responsable == comp.responsable
         assert nuevo_comp.condicion_fiscal == comp.condicion_fiscal
-        assert nuevo_comp.total_facturado == 200
+        assert nuevo_comp.total_facturado == Decimal(200).quantize(Decimal(10)**-2)
         assert nuevo_comp.tipo_comprobante == TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA)
         assert nuevo_comp.nro_terminal == comp.nro_terminal
 
@@ -103,13 +104,13 @@ class TestComprobantesAsociados(TestCase):
         comp.tipo_comprobante = TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA)
         comp.save()
 
-        nuevo_comp = crear_comprobante_asociado(1, 300, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(300), '')
 
         assert nuevo_comp.nombre_cliente == comp.nombre_cliente
         assert nuevo_comp.nro_cuit == comp.nro_cuit
         assert nuevo_comp.responsable == comp.responsable
         assert nuevo_comp.condicion_fiscal == comp.condicion_fiscal
-        assert nuevo_comp.total_facturado == 300
+        assert nuevo_comp.total_facturado == Decimal(300).quantize(Decimal(10)**-2)
         assert nuevo_comp.tipo_comprobante == TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA)
         assert nuevo_comp.nro_terminal == comp.nro_terminal
 
@@ -121,19 +122,19 @@ class TestComprobantesAsociados(TestCase):
         comp = Comprobante.objects.get(pk = 1)
         comp.tipo_comprobante = TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA)
         comp.save()
-        nuevo_comp = crear_comprobante_asociado(1, 400, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(400), '')
 
         assert nuevo_comp.nombre_cliente == comp.nombre_cliente
         assert nuevo_comp.nro_cuit == comp.nro_cuit
         assert nuevo_comp.responsable == comp.responsable
         assert nuevo_comp.condicion_fiscal == comp.condicion_fiscal
-        assert nuevo_comp.total_facturado == 400
+        assert nuevo_comp.total_facturado == Decimal(400).quantize(Decimal(10)**-2)
         assert nuevo_comp.tipo_comprobante == TipoComprobante.objects.get(pk = ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA)
         assert nuevo_comp.nro_terminal == comp.nro_terminal
 
     def test_crear_comprobante_asociado_falla_si_el_comprobante_no_existe(self):
         with self.assertRaises(Comprobante.DoesNotExist):
-            crear_comprobante_asociado(50, 100, '')
+            crear_comprobante_asociado(50, Decimal(100), '')
 
     @patch('comprobante.comprobante_asociado.Afip')
     def test_guarda_linea_en_db(self, afip_mock):
@@ -142,12 +143,12 @@ class TestComprobantesAsociados(TestCase):
 
         cantidad_inicial = LineaDeComprobante.objects.count()
 
-        nuevo_comp = crear_comprobante_asociado(1, 400, '')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(400), '')
 
         assert cantidad_inicial + 1 == LineaDeComprobante.objects.count()
         assert LineaDeComprobante.objects.latest('id').concepto == 'AJUSTA FACTURA {} No {}-{} SEGUN DEBITO APLICADO'.format(nuevo_comp.sub_tipo, nuevo_comp.nro_terminal, nuevo_comp.numero)
 
-        nuevo_comp = crear_comprobante_asociado(1, 400, 'prueba')
+        nuevo_comp = crear_comprobante_asociado(1, Decimal(400), 'prueba')
 
         assert cantidad_inicial + 2 == LineaDeComprobante.objects.count()
         assert LineaDeComprobante.objects.latest('id').concepto == 'prueba'
@@ -160,14 +161,14 @@ class TestComprobantesAsociados(TestCase):
         cantidad_inicial = LineaDeComprobante.objects.count()
 
         with self.assertRaises(AfipErrorValidacion):
-            crear_comprobante_asociado(1,199,'')
+            crear_comprobante_asociado(1, Decimal(199), '')
         
         assert cantidad_inicial == LineaDeComprobante.objects.count()
         
         afip.emitir_comprobante.side_effect = AfipErrorRed
 
         with self.assertRaises(AfipErrorRed):
-            crear_comprobante_asociado(1, 100, '')
+            crear_comprobante_asociado(1, Decimal(100), '')
 
         assert cantidad_inicial == LineaDeComprobante.objects.count()
 
@@ -176,7 +177,7 @@ class TestComprobantesAsociados(TestCase):
         afip_mock.side_effect = AfipErrorRed
 
         with self.assertRaises(AfipErrorRed):
-            crear_comprobante_asociado(1, 100, '')
+            crear_comprobante_asociado(1, Decimal(100), '')
 
     @patch('comprobante.comprobante_asociado.Afip')
     def test_crear_comprobante_asociado_falla_si_afip_no_valida_el_comprobante(self, afip_mock):
@@ -185,7 +186,7 @@ class TestComprobantesAsociados(TestCase):
         afip.emitir_comprobante.side_effect = AfipErrorValidacion
 
         with self.assertRaises(AfipErrorValidacion):
-            crear_comprobante_asociado(1, 100, '')
+            crear_comprobante_asociado(1, Decimal(100), '')
 
     @patch('comprobante.comprobante_asociado.Afip')
     def test_comprobante_no_se_guarda_en_bd_si_afip_devuelve_error(self, afip_mock):
@@ -196,13 +197,13 @@ class TestComprobantesAsociados(TestCase):
         cantidad_inicial = Comprobante.objects.count()
 
         with self.assertRaises(AfipErrorValidacion):
-            crear_comprobante_asociado(1,199,'')
+            crear_comprobante_asociado(1, Decimal(199), '')
         
         assert cantidad_inicial == Comprobante.objects.count()
         
         afip.emitir_comprobante.side_effect = AfipErrorRed
 
         with self.assertRaises(AfipErrorRed):
-            crear_comprobante_asociado(1, 100, '')
+            crear_comprobante_asociado(1, Decimal(100), '')
 
         assert cantidad_inicial == Comprobante.objects.count()


### PR DESCRIPTION
Una vez mas, un fix nuevo para la afip. 
Se le agrega obligatoriamente los dos decimales para los comprobantes