### PR TITLE
Arreglos sobre pacientes y AMR

### DIFF
--- a/paciente/serializers.py
+++ b/paciente/serializers.py
@@ -14,7 +14,7 @@ class PacienteFormSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Paciente
-        fields = ['dni', 'nombre', 'apellido', 'domicilio', 'telefono', 'sexo', 'fechaNacimiento', 'nroAfiliado', 'email']
+        fields = ['id', 'dni', 'nombre', 'apellido', 'domicilio', 'telefono', 'sexo', 'fechaNacimiento', 'nroAfiliado', 'email']
 
     def to_internal_value(self, data):
         dni = data.get(u'dni')
@@ -43,6 +43,6 @@ class PacienteFormSerializer(serializers.ModelSerializer):
         return dni
 
     def validate_nroAfiliado(self, nroAfiliado):
-        if not nroAfiliado.isalnum():
+        if not all(x.isalnum() or x.isspace() for x in nroAfiliado):
             raise serializers.ValidationError('Error, el numero de afiliado debe contener solo letras y numeros')
         return nroAfiliado

--- a/paciente/serializers.py
+++ b/paciente/serializers.py
@@ -18,7 +18,7 @@ class PacienteFormSerializer(serializers.ModelSerializer):
 
     def to_internal_value(self, data):
         dni = data.get(u'dni')
-        fecha_nacimiento = data.get(u'fechaNacimiento')
+        fecha_nacimiento = data.get(u'fecha_nacimiento')
 
         if fecha_nacimiento:
             fecha_nacimiento = datetime.strptime(fecha_nacimiento, settings.FORMAT_DATE)

--- a/paciente/serializers.py
+++ b/paciente/serializers.py
@@ -37,11 +37,6 @@ class PacienteFormSerializer(serializers.ModelSerializer):
 
         return super(PacienteFormSerializer, self).to_internal_value(datos)
 
-    def validate_dni(self, dni):
-        if Paciente.objects.filter(dni=dni).exists():
-            raise serializers.ValidationError('Error, ya existe un paciente con DNI ' + str(dni))
-        return dni
-
     def validate_nroAfiliado(self, nroAfiliado):
         if not all(x.isalnum() or x.isspace() for x in nroAfiliado):
             raise serializers.ValidationError('Error, el numero de afiliado debe contener solo letras y numeros')

--- a/paciente/serializers.py
+++ b/paciente/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 from paciente.models import Paciente
+from datetime import datetime
+from django.conf import settings
 
 
 class PacienteSerializer(serializers.HyperlinkedModelSerializer):
@@ -8,3 +10,21 @@ class PacienteSerializer(serializers.HyperlinkedModelSerializer):
         model = Paciente
         fields = (u'id', u'dni', u'nombre', u'apellido', u'_edad')
 
+class PacienteFormSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = Paciente
+        fields = ['dni', 'nombre', 'apellido', 'domicilio', 'telefono', 'sexo', 'fechaNacimiento', 'nroAfiliado', 'email']
+    
+    def validate_dni(self, dni):
+        if Paciente.objects.filter(dni=dni).count() > 0:
+            raise serializers.ValidationError('Error, ya existe un paciente con DNI ' + str(dni))
+        return dni
+
+    def validate_nroAfiliado(self, nroAfiliado):
+        if not nroAfiliado.isalnum():
+            raise serializers.ValidationError('Error, el numero de afiliado debe contener solo letras y numeros')
+        return nroAfiliado
+
+    def validate_fechaNacimiento(self, fechaNacimiento):
+        return datetime.strptime(fechaNacimiento, settings.FORMAT_DATE) if fechaNacimiento else None

--- a/paciente/tests.py
+++ b/paciente/tests.py
@@ -16,7 +16,7 @@ class TestFormularioPaciente(TestCase):
             'domicilio': 'Calle Falsa 123',
             'telefono': '123456789',
             'sexo': 'Femenino',
-            'fechaNacimiento': '01/01/1976',
+            'fecha_nacimiento': '01/01/1976',
             'nro_afiliado': '12345',
             'email': 'lalala123@gmail.com',
         }

--- a/paciente/tests.py
+++ b/paciente/tests.py
@@ -2,7 +2,6 @@ from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from paciente.models import Paciente
 import json
-# Create your tests here.
 
 class TestFormularioPaciente(TestCase):
     fixtures = ['pacientes.json']

--- a/paciente/tests.py
+++ b/paciente/tests.py
@@ -1,3 +1,106 @@
-from django.test import TestCase
-
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from paciente.models import Paciente
+import json
 # Create your tests here.
+
+class TestFormularioPaciente(TestCase):
+    fixtures = ['pacientes.json']
+    def setUp(self):
+        self.user = User.objects.create_user(username='test', password='test', is_superuser=True)
+        self.client = Client(HTTP_GET='localhost')
+        self.client.login(username='test', password='test')
+        self.paciente_prueba = {
+            'nombre': 'Test',
+            'apellido': 'Pacientes',
+            'dni': 12312313,
+            'domicilio': 'Calle Falsa 123',
+            'telefono': '123456789',
+            'sexo': 'M',
+            'fechaNacimiento': '01/01/1976',
+            'nro_afiliado': '12345',
+            'email': 'lalala123@gmail.com',
+        }
+
+    def test_crear_paciente_falla_si_dni_existe_en_db(self):
+        paciente_db = Paciente.objects.get(pk=1)
+        paciente = self.paciente_prueba
+        paciente['dni'] = paciente_db.dni
+
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+
+        assert response['status'] == 0
+
+        paciente['dni'] = 12312313
+
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+
+        assert response['status'] == 1
+
+    def test_crear_paciente_falla_si_nro_afiliado_no_es_alfanumerico(self):
+        paciente = self.paciente_prueba
+        paciente['nro_afiliado'] = '12345.'
+
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+        assert response['status'] == 0
+
+        paciente['nro_afiliado'] = '12345 ab,cd'
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+        assert response['status'] == 0
+
+        paciente['nro_afiliado'] = '12345 abcd!'
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+        assert response['status'] == 0
+
+        paciente['nro_afiliado'] = '12345 abcd'
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+        assert response['status'] == 1
+
+    def test_crear_paciente_guarda_paciente_en_db(self):
+        cantidad_inicial = Paciente.objects.count()
+        response = json.loads(self.client.post('/paciente/nuevo/', self.paciente_prueba).content)
+
+        assert response['status'] == 1
+        assert Paciente.objects.count() == cantidad_inicial + 1
+
+    def test_crear_paciente_no_guarda_paciente_en_db_si_falla(self):
+        cantidad_inicial = Paciente.objects.count()
+        self.paciente_prueba['nro_afiliado'] = '12345!'
+        response = json.loads(self.client.post('/paciente/nuevo/', self.paciente_prueba).content)
+
+        assert response['status'] == 0
+        assert Paciente.objects.count() == cantidad_inicial
+
+    def test_update_paciente_falla_si_dni_existe_en_db(self):
+        paciente_db = Paciente.objects.get(pk=1)
+        paciente = self.paciente_prueba
+        paciente['dni'] = paciente_db.dni
+
+        response = json.loads(self.client.post('/paciente/2/actualizar/', paciente).content)
+
+        assert response['status'] == 0
+
+        paciente['dni'] = 12312313
+
+        response = json.loads(self.client.post('/paciente/2/actualizar/', paciente).content)
+
+        assert response['status'] == 1
+
+    def test_update_paciente_falla_si_nro_afiliado_no_es_alfanumerico(self):
+        paciente = self.paciente_prueba
+        paciente['nro_afiliado'] = '12345.'
+
+        response = json.loads(self.client.post('/paciente/1/actualizar/', paciente).content)
+        assert response['status'] == 0
+
+        paciente['nro_afiliado'] = '12345 ab,cd'
+        response = json.loads(self.client.post('/paciente/1/actualizar/', paciente).content)
+        assert response['status'] == 0
+
+        paciente['nro_afiliado'] = '12345 abcd!'
+        response = json.loads(self.client.post('/paciente/1/actualizar/', paciente).content)
+        assert response['status'] == 0
+
+        paciente['nro_afiliado'] = '12345 abcd'
+        response = json.loads(self.client.post('/paciente/1/actualizar/', paciente).content)
+        assert response['status'] == 1

--- a/paciente/tests.py
+++ b/paciente/tests.py
@@ -103,3 +103,23 @@ class TestFormularioPaciente(TestCase):
         paciente['nro_afiliado'] = '12345 abcd'
         response = json.loads(self.client.post('/paciente/1/actualizar/', paciente).content)
         assert response['status'] == 1
+    
+    def test_update_actualiza_paciente_en_db(self):
+        paciente = self.paciente_prueba
+
+        response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
+        assert response['status'] == 1
+
+        paciente['nro_afiliado'] = '12345'
+        paciente['nombre'] = 'Jorge'
+        paciente['dni'] = 5248624
+
+        id_paciente = response['idPaciente']
+
+        response = json.loads(self.client.post('/paciente/{}/actualizar/'.format(id_paciente), paciente).content)
+
+        paciente_act = Paciente.objects.get(pk=id_paciente)
+
+        assert paciente_act.nroAfiliado == '12345'
+        assert paciente_act.nombre == 'Jorge'
+        assert paciente_act.dni == 5248624

--- a/paciente/tests.py
+++ b/paciente/tests.py
@@ -16,7 +16,7 @@ class TestFormularioPaciente(TestCase):
             'dni': 12312313,
             'domicilio': 'Calle Falsa 123',
             'telefono': '123456789',
-            'sexo': 'M',
+            'sexo': 'Femenino',
             'fechaNacimiento': '01/01/1976',
             'nro_afiliado': '12345',
             'email': 'lalala123@gmail.com',

--- a/paciente/tests.py
+++ b/paciente/tests.py
@@ -110,16 +110,27 @@ class TestFormularioPaciente(TestCase):
         response = json.loads(self.client.post('/paciente/nuevo/', paciente).content)
         assert response['status'] == 1
 
-        paciente['nro_afiliado'] = '12345'
-        paciente['nombre'] = 'Jorge'
+        paciente['nombre'] = 'Bonnie'
+        paciente['apellido'] = 'Clyde'
         paciente['dni'] = 5248624
+        paciente['domicilio'] = 'Direccion prueba 456'
+        paciente['telefono'] = '789456123'
+        paciente['sexo'] = 'Masculino'
+        paciente['fecha_nacimiento'] = '02/02/1985'
+        paciente['nro_afiliado'] = '12345'
+        paciente['email'] = 'maildeprueba@gmail.com'
 
         id_paciente = response['idPaciente']
 
         response = json.loads(self.client.post('/paciente/{}/actualizar/'.format(id_paciente), paciente).content)
 
         paciente_act = Paciente.objects.get(pk=id_paciente)
-
-        assert paciente_act.nroAfiliado == '12345'
-        assert paciente_act.nombre == 'Jorge'
+        assert paciente_act.nombre == 'Bonnie'
+        assert paciente_act.apellido == 'Clyde'
         assert paciente_act.dni == 5248624
+        assert paciente_act.domicilio == 'Direccion prueba 456'
+        assert paciente_act.telefono == '789456123'
+        assert paciente_act.sexo == 'Masculino'
+        assert paciente_act.fechaNacimiento.strftime('%d/%m/%Y') == '02/02/1985'
+        assert paciente_act.nroAfiliado == '12345'
+        assert paciente_act.email == 'maildeprueba@gmail.com'

--- a/paciente/views.py
+++ b/paciente/views.py
@@ -104,29 +104,18 @@ def buscar_form(request):
 
 
 def create(request):
-    dni = request.POST.get(u'dni')
-    data = {
-        'nombre': request.POST.get('nombre'),
-        'apellido': request.POST.get('apellido'),
-        'nroAfiliado': request.POST.get(u'nro_afiliado', u''),
-        'domicilio': request.POST.get(u'domicilio', u''),
-        'sexo': request.POST.get(u'sexo', u''),
-        'telefono': request.POST.get(u'telefono', u''),
-        'dni': int(dni) if dni else 0,
-        'fechaNacimiento': request.POST.get('fecha_nacimiento'),
-        'email':request.POST.get(u'email'),
-    }
-
-    paciente = PacienteFormSerializer(data = data)
+    paciente = PacienteFormSerializer(data = request.POST)
 
     response_dict = {
         'status': 1,
         'message': 'El paciente se ha creado correctamente.'
     }
 
-    if not paciente.is_valid():
+    if paciente.is_valid():
+        paciente.save()
+    else:
         response_dict = {'status': 0, 'message': paciente.errors}
-    
+
     return HttpResponse(simplejson.dumps(response_dict))
 
 def update(request, id_paciente):

--- a/paciente/views.py
+++ b/paciente/views.py
@@ -129,7 +129,7 @@ def update(request, id_paciente):
     if paciente.is_valid():
         paciente.save()
     else:
-        response_dict = {'status': 0, 'message': paciente.errors}
+        response_dict = {'status': 0, 'message': paciente.errors[next(iter(paciente.errors))]}
 
     return HttpResponse(simplejson.dumps(response_dict))
 

--- a/paciente/views.py
+++ b/paciente/views.py
@@ -105,6 +105,21 @@ def buscar_form(request):
 
 def create(request):
     paciente = PacienteFormSerializer(data = request.POST)
+    response_dict = {
+        'status': 1,
+        'message': 'El paciente se ha creado correctamente.'
+    }
+
+    if paciente.is_valid():
+        paciente.save()
+        response_dict['idPaciente'] = paciente['id'].value
+    else:
+        response_dict = {'status': 0, 'message': paciente.errors}
+
+    return HttpResponse(simplejson.dumps(response_dict))
+
+def update(request, id_paciente):
+    paciente = PacienteFormSerializer(Paciente.objects.get(pk=id_paciente), data = request.POST)
 
     response_dict = {
         'status': 1,
@@ -117,51 +132,6 @@ def create(request):
         response_dict = {'status': 0, 'message': paciente.errors}
 
     return HttpResponse(simplejson.dumps(response_dict))
-
-def update(request, id_paciente):
-    nroAfiliado = request.POST.get(u'nro_afiliado', u'')
-    domicilio = request.POST.get(u'domicilio', u'')
-    sexo = request.POST.get(u'sexo', u'')
-    dni = request.POST.get(u'dni')
-    dni = int(dni) if dni else 0
-
-    paciente = get_object_or_404(Paciente, pk=id_paciente)
-
-    fecha_nacimiento = request.POST.get('fecha_nacimiento')
-    if fecha_nacimiento:
-        fecha_nacimiento = datetime.strptime(fecha_nacimiento, settings.FORMAT_DATE)
-
-    if dni > 0:  # revisar que el DNI no este duplicado, a menos que sea 0
-        pacientes = Paciente.objects.filter(dni=dni).exclude(id=paciente.id)
-        if pacientes.exists():
-            response_dict = {'status': 0, 'message': "Error, ya existe un paciente con DNI " + str(dni)}
-            return HttpResponse(simplejson.dumps(response_dict))
-
-    if not nroAfiliado.isalnum():
-        response_dict = {'status': 0, 'message': 'Error, el numero de afiliado debe contener solo letras y numeros'}
-        return HttpResponse(simplejson.dumps(response_dict))
-        
-    try:
-        paciente.dni = dni
-        paciente.nombre = request.POST['nombre']
-        paciente.apellido = request.POST['apellido']
-        paciente.domicilio = domicilio
-        paciente.telefono = request.POST['telefono']
-        paciente.sexo = sexo
-        paciente.fechaNacimiento = fecha_nacimiento
-        paciente.nroAfiliado = nroAfiliado
-        paciente.email = request.POST.get(u'email')
-        paciente.save()
-
-        response_dict = {'status': 1, 'message': "El paciente se ha modificado correctamente."}
-        return HttpResponse(simplejson.dumps(response_dict))
-
-    except Exception as err:
-        response_dict = {
-            'status': 0,
-            'message': "Ocurrio un error. Revise los datos y vuelva a intentarlo." + "Error:" + str(err)
-        }
-        return HttpResponse(simplejson.dumps(response_dict))
 
 class PacienteNombreApellidoODniFilterBackend(filters.BaseFilterBackend):
     

--- a/paciente/views.py
+++ b/paciente/views.py
@@ -104,6 +104,7 @@ def buscar_form(request):
 
 
 def create(request):
+    nroAfiliado = request.POST.get(u'nro_afiliado', u'')
     domicilio = request.POST.get(u'domicilio', u'')
     sexo = request.POST.get(u'sexo', u'')
     dni = request.POST.get(u'dni')
@@ -121,6 +122,10 @@ def create(request):
             response_dict = {'status': 0, 'message': "Error, ya existe un paciente con DNI " + str(dni)}
             return HttpResponse(simplejson.dumps(response_dict))
 
+    if not nroAfiliado.isalnum():
+        response_dict = {'status': 0, 'message': 'Error, el numero de afiliado debe contener solo letras y numeros'}
+        return HttpResponse(simplejson.dumps(response_dict))
+        
     try:
         paciente = Paciente()
         paciente.nombre = request.POST['nombre']
@@ -130,7 +135,7 @@ def create(request):
         paciente.telefono = request.POST['telefono']
         paciente.sexo = sexo
         paciente.fechaNacimiento = fecha_nacimiento
-        paciente.nroAfiliado = request.POST.get(u'nro_afiliado', u'')
+        paciente.nroAfiliado = nroAfiliado
         paciente.email = request.POST.get(u'email')
         paciente.save()
 
@@ -147,6 +152,7 @@ def create(request):
 
 
 def update(request, id_paciente):
+    nroAfiliado = request.POST.get(u'nro_afiliado', u'')
     domicilio = request.POST.get(u'domicilio', u'')
     sexo = request.POST.get(u'sexo', u'')
     dni = request.POST.get(u'dni')
@@ -164,6 +170,10 @@ def update(request, id_paciente):
             response_dict = {'status': 0, 'message': "Error, ya existe un paciente con DNI " + str(dni)}
             return HttpResponse(simplejson.dumps(response_dict))
 
+    if not nroAfiliado.isalnum():
+        response_dict = {'status': 0, 'message': 'Error, el numero de afiliado debe contener solo letras y numeros'}
+        return HttpResponse(simplejson.dumps(response_dict))
+        
     try:
         paciente.dni = dni
         paciente.nombre = request.POST['nombre']
@@ -172,7 +182,7 @@ def update(request, id_paciente):
         paciente.telefono = request.POST['telefono']
         paciente.sexo = sexo
         paciente.fechaNacimiento = fecha_nacimiento
-        paciente.nroAfiliado = request.POST.get(u'nro_afiliado', u'')
+        paciente.nroAfiliado = nroAfiliado
         paciente.email = request.POST.get(u'email')
         paciente.save()
 

--- a/paciente/views.py
+++ b/paciente/views.py
@@ -114,7 +114,7 @@ def create(request):
         paciente.save()
         response_dict['idPaciente'] = paciente['id'].value
     else:
-        response_dict = {'status': 0, 'message': paciente.errors}
+        response_dict = {'status': 0, 'message': paciente.errors[next(iter(paciente.errors))]}
 
     return HttpResponse(simplejson.dumps(response_dict))
 

--- a/paciente/views.py
+++ b/paciente/views.py
@@ -123,7 +123,7 @@ def update(request, id_paciente):
 
     response_dict = {
         'status': 1,
-        'message': 'El paciente se ha creado correctamente.'
+        'message': 'El paciente se ha actualizado correctamente.'
     }
 
     if paciente.is_valid():

--- a/presentacion/obra_social_custom_code/amr_presentacion_digital.py
+++ b/presentacion/obra_social_custom_code/amr_presentacion_digital.py
@@ -1,6 +1,5 @@
 from decimal import Decimal, ROUND_UP
 
-
 class AmrRowBase(object):
     def __init__(self, estudio, comprobante, *args, **kwargs):
         """
@@ -51,7 +50,7 @@ class AmrRowBase(object):
         self.nombre_de_nomenclador_prestacional = u'{:<30}'.format(unicode(estudio.practica)[:30])
         self.cantidad = u'00001'
         self.matricula_del_efector = '{0:06}'.format(self.format_nro_matricula(estudio.medico))
-        self.nombre_del_efector = u'{:<30}'.format(remove_non_ascii_character(unicode(estudio.medico))[:30])
+        self.nombre_del_efector = u'{:<30}'.format(remove_non_ascii_character(unicode(get_nombre_medico(estudio.medico)))[:30])
         self.honorarios = '0{0:013}'.format(importe).replace('.', '')
         self.derechos = '0{0:013}'.format(importe_pension).replace('.', '')
         self.tipo_de_honorario = u'0'
@@ -88,7 +87,8 @@ class AmrRowBase(object):
         except ValueError:
             raise ValueError("Error con la matricula del medico {}({}) - Matricula {}".format(medico.apellido, medico.id,
                                                                                               nro_matricula))
-
+    def get_nombre_medico(self, medico):
+        return medico if medico.facturar_amr_en_nombre_de_medico == None else medico.facturar_amr_en_nombre_de_medico
 
 class AmrRowEstudio(AmrRowBase):
     def __init__(self, estudio, *args, **kwargs):

--- a/presentacion/obra_social_custom_code/amr_presentacion_digital.py
+++ b/presentacion/obra_social_custom_code/amr_presentacion_digital.py
@@ -50,7 +50,7 @@ class AmrRowBase(object):
         self.nombre_de_nomenclador_prestacional = u'{:<30}'.format(unicode(estudio.practica)[:30])
         self.cantidad = u'00001'
         self.matricula_del_efector = '{0:06}'.format(self.format_nro_matricula(estudio.medico))
-        self.nombre_del_efector = u'{:<30}'.format(remove_non_ascii_character(unicode(get_nombre_medico(estudio.medico)))[:30])
+        self.nombre_del_efector = u'{:<30}'.format(remove_non_ascii_character(unicode(self.get_nombre_medico(estudio.medico)))[:30])
         self.honorarios = '0{0:013}'.format(importe).replace('.', '')
         self.derechos = '0{0:013}'.format(importe_pension).replace('.', '')
         self.tipo_de_honorario = u'0'

--- a/presentacion/tests.py
+++ b/presentacion/tests.py
@@ -37,6 +37,14 @@ class TestDetallesObrasSociales(TestCase):
         response = self.client.get('/api/presentacion/1/get_detalle_amr/')
         assert response.content != ''
 
+    def test_detalle_amr_no_posee_caracter_de_nueva_linea_y_barra_invertida_al_final(self):
+        presentacion = Presentacion.objects.get(pk=1)
+        presentacion.fecha_cobro = None
+        presentacion.save()
+        response = self.client.get('/api/presentacion/1/get_detalle_amr/')
+        assert response.content[-1] != '\\'
+        assert response.content[-1] != '\n'
+
 class TestEstudiosDePresentacion(TestCase):
     fixtures = ['pacientes.json', 'medicos.json', 'practicas.json', 'obras_sociales.json', 'anestesistas.json', 'presentaciones.json', 'comprobantes.json', 'estudios.json']
 

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -75,7 +75,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
             for estudio in estudios:
                 csv_string = '{}{}\n'.format(csv_string, AmrRowEstudio(estudio, comprobante).get_row())
 
-            response = HttpResponse(csv_string, content_type='text/plain')
+            response = HttpResponse(csv_string[:-1], content_type='text/plain')
         except Exception as ex:
             response = HttpResponse(simplejson.dumps({'error': ex.message}), status=500, content_type='application/json')
         return response

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -73,7 +73,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
             comprobante = presentacion.comprobante
 
             for estudio in estudios:
-                csv_string = '{}\n{}'.format(csv_string, AmrRowEstudio(estudio, comprobante).get_row())
+                csv_string = '{}{}\n'.format(csv_string, AmrRowEstudio(estudio, comprobante).get_row())
 
             response = HttpResponse(csv_string, content_type='text/plain')
         except Exception as ex:


### PR DESCRIPTION
Se quita en el formato AMR la primer linea vacia y se verifica en el formulario de pacientes que se encuentra en turnos si el numero de afiliado es alfanumerico