### PR TITLE
Mas ajustes antes del release Presentacion

### DIFF
--- a/comprobante/afip.py
+++ b/comprobante/afip.py
@@ -3,6 +3,7 @@
 Modulo encargado de la comunicacion con el Webservice de la AFIP.
 '''
 from datetime import date, datetime, timedelta
+from decimal import Decimal, ROUND_UP
 from xml.parsers.expat import ExpatError
 from httplib2 import ServerNotFoundError
 
@@ -158,10 +159,10 @@ class _Afip(object):
             punto_vta=comprobante_cedir.nro_terminal,
             cbt_desde=nro,
             cbt_hasta=nro,
-            imp_total=comprobante_cedir.total_facturado,
-            imp_neto=imp_neto,
-            imp_iva=imp_iva,
-            imp_op_ex=imp_op_ex,
+            imp_total=comprobante_cedir.total_facturado.quantize(Decimal('.01'), ROUND_UP),
+            imp_neto=imp_neto.quantize(Decimal('.01'), ROUND_UP),
+            imp_iva=imp_iva.quantize(Decimal('.01'), ROUND_UP),
+            imp_op_ex=imp_op_ex.quantize(Decimal('.01'), ROUND_UP),
             fecha_cbte=fecha, # Estas fechas no cambian nunca, pero son requisito de la AFIP para el concepto=2
             fecha_serv_desde=fecha,
             fecha_serv_hasta=fecha,
@@ -169,9 +170,15 @@ class _Afip(object):
 
         # Agregar el IVA
         if comprobante_cedir.gravado.id == IVA_10_5:
-            self.webservice.AgregarIva(iva_id=4, base_imp=imp_neto, importe=imp_iva)
+            self.webservice.AgregarIva(
+                iva_id=4,
+                base_imp=imp_neto.quantize(Decimal('.01'), ROUND_UP),
+                importe=imp_iva.quantize(Decimal('.01'), ROUND_UP))
         elif comprobante_cedir.gravado.id == IVA_21:
-            self.webservice.AgregarIva(iva_id=5, base_imp=imp_neto, importe=imp_iva)
+            self.webservice.AgregarIva(
+                iva_id=5,
+                base_imp=imp_neto.quantize(Decimal('.01'), ROUND_UP),
+                importe=imp_iva.quantize(Decimal('.01'), ROUND_UP))
 
         # Si hay comprobantes asociados, los agregamos.
         if comprobante_cedir.tipo_comprobante.id in [

--- a/comprobante/afip.py
+++ b/comprobante/afip.py
@@ -144,12 +144,12 @@ class _Afip(object):
         fecha_vto = None if comprobante_cedir.tipo_comprobante.id in [ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA, ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA] else comprobante_cedir.fecha_vencimiento.strftime("%Y%m%d")
         imp_iva = sum([l.iva for l in lineas])
         if comprobante_cedir.gravado.id == IVA_EXCENTO:
-            imp_neto = "0.00"
+            imp_neto = Decimal("0.00")
             imp_op_ex = sum([l.importe_neto for l in lineas])
         else:
             # importe neto gravado (todas las alicuotas)
             imp_neto = sum([l.importe_neto for l in lineas])
-            imp_op_ex = "0.00"        # importe total operaciones exentas
+            imp_op_ex = Decimal("0.00")        # importe total operaciones exentas
 
         self.webservice.CrearFactura(
             concepto=2,  # 2 es servicios, lo unico que hace el cedir.
@@ -159,10 +159,10 @@ class _Afip(object):
             punto_vta=comprobante_cedir.nro_terminal,
             cbt_desde=nro,
             cbt_hasta=nro,
-            imp_total=comprobante_cedir.total_facturado.quantize(Decimal('.01'), ROUND_UP),
-            imp_neto=imp_neto.quantize(Decimal('.01'), ROUND_UP),
-            imp_iva=imp_iva.quantize(Decimal('.01'), ROUND_UP),
-            imp_op_ex=imp_op_ex.quantize(Decimal('.01'), ROUND_UP),
+            imp_total=Decimal(comprobante_cedir.total_facturado).quantize(Decimal('.01'), ROUND_UP),
+            imp_neto=Decimal(imp_neto).quantize(Decimal('.01'), ROUND_UP),
+            imp_iva=Decimal(imp_iva).quantize(Decimal('.01'), ROUND_UP),
+            imp_op_ex=Decimal(imp_op_ex).quantize(Decimal('.01'), ROUND_UP),
             fecha_cbte=fecha, # Estas fechas no cambian nunca, pero son requisito de la AFIP para el concepto=2
             fecha_serv_desde=fecha,
             fecha_serv_hasta=fecha,
@@ -172,13 +172,13 @@ class _Afip(object):
         if comprobante_cedir.gravado.id == IVA_10_5:
             self.webservice.AgregarIva(
                 iva_id=4,
-                base_imp=imp_neto.quantize(Decimal('.01'), ROUND_UP),
-                importe=imp_iva.quantize(Decimal('.01'), ROUND_UP))
+                base_imp=Decimal(imp_neto).quantize(Decimal('.01'), ROUND_UP),
+                importe=Decimal(imp_iva).quantize(Decimal('.01'), ROUND_UP))
         elif comprobante_cedir.gravado.id == IVA_21:
             self.webservice.AgregarIva(
                 iva_id=5,
-                base_imp=imp_neto.quantize(Decimal('.01'), ROUND_UP),
-                importe=imp_iva.quantize(Decimal('.01'), ROUND_UP))
+                base_imp=Decimal(imp_neto).quantize(Decimal('.01'), ROUND_UP),
+                importe=Decimal(imp_iva).quantize(Decimal('.01'), ROUND_UP))
 
         # Si hay comprobantes asociados, los agregamos.
         if comprobante_cedir.tipo_comprobante.id in [

--- a/comprobante/models.py
+++ b/comprobante/models.py
@@ -9,6 +9,10 @@ ID_TIPO_COMPROBANTE_FACTURA_CREDITO_ELECTRONICA = 5
 ID_TIPO_COMPROBANTE_NOTA_DE_DEBITO_ELECTRONICA = 6
 ID_TIPO_COMPROBANTE_NOTA_DE_CREDITO_ELECTRONICA = 7
 
+ID_DOCUMENTO_AFIP_TIPO_CUIT = 80
+ID_DOCUMENTO_AFIP_TIPO_CUIL = 86
+ID_DOCUMENTO_AFIP_TIPO_DNI = 96
+
 class TipoComprobante(models.Model):
     nombre = models.CharField(max_length=128, db_column=u'tipoComprobante')
 
@@ -85,7 +89,12 @@ class Comprobante(models.Model):
 
     @property
     def tipo_id_afip(self):
-        return 80 if len(self.nro_cuit.replace('-', '')) > 10 else 96
+        if len(self.nro_cuit.replace('-', '')) <= 9:
+            return ID_DOCUMENTO_AFIP_TIPO_DNI
+        elif self.nro_cuit[0] == '2':
+            return ID_DOCUMENTO_AFIP_TIPO_CUIL
+        else:
+            return ID_DOCUMENTO_AFIP_TIPO_CUIT
 
     @property
     def nro_id_afip(self):

--- a/comprobante/serializers.py
+++ b/comprobante/serializers.py
@@ -204,9 +204,7 @@ class CrearComprobanteAFIPSerializer(serializers.ModelSerializer):
         responsable = validated_data['responsable']
         tipo_comprobante = TipoComprobante.objects.get(pk=validated_data['tipo_comprobante_id'])
         iva = neto * gravado.porcentaje / Decimal("100.00")
-        iva = iva.quantize(Decimal('.01'), ROUND_UP)
         total = neto + iva
-        total = total.quantize(Decimal('.01'), ROUND_UP)
         concepto = validated_data["concepto"]
         del validated_data["neto"]
         del validated_data["concepto"]

--- a/comprobante/serializers.py
+++ b/comprobante/serializers.py
@@ -204,7 +204,9 @@ class CrearComprobanteAFIPSerializer(serializers.ModelSerializer):
         responsable = validated_data['responsable']
         tipo_comprobante = TipoComprobante.objects.get(pk=validated_data['tipo_comprobante_id'])
         iva = neto * gravado.porcentaje / Decimal("100.00")
+        iva = iva.quantize(Decimal('.01'), ROUND_UP)
         total = neto + iva
+        total = total.quantize(Decimal('.01'), ROUND_UP)
         concepto = validated_data["concepto"]
         del validated_data["neto"]
         del validated_data["concepto"]

--- a/comprobante/tests_afip.py
+++ b/comprobante/tests_afip.py
@@ -4,7 +4,8 @@ from httplib2 import ServerNotFoundError
 from mock import patch
 
 from django.test import TestCase
-from comprobante.models import Comprobante, TipoComprobante, Gravado, LineaDeComprobante
+from comprobante.models import Comprobante, TipoComprobante, Gravado, LineaDeComprobante, \
+    ID_DOCUMENTO_AFIP_TIPO_CUIT, ID_DOCUMENTO_AFIP_TIPO_CUIL, ID_DOCUMENTO_AFIP_TIPO_DNI
 from comprobante.afip import Afip, AfipErrorValidacion, AfipErrorRed
 
 
@@ -645,3 +646,28 @@ class TestAfipAPI(TestCase):
         })]
         afip.emitir_comprobante(nota_de_credito_electronica, lineas_nota_de_credito_electronica)
         assert nota_de_credito_electronica.cae == 1
+
+class TestTipoIdAfip(TestCase):
+    fixtures = ["comprobantes.json"]
+
+    def test_dni(self):
+        comprobante = Comprobante.objects.get(pk=1)
+        comprobante.nro_cuit = "38905723"
+        comprobante.save()
+        comprobante = Comprobante.objects.get(pk=1)
+        assert comprobante.tipo_id_afip == ID_DOCUMENTO_AFIP_TIPO_DNI
+
+    def test_cuil(self):
+        comprobante = Comprobante.objects.get(pk=1)
+        comprobante.nro_cuit = "20-38905723-7"
+        comprobante.save()
+        comprobante = Comprobante.objects.get(pk=1)
+        assert comprobante.tipo_id_afip == ID_DOCUMENTO_AFIP_TIPO_CUIL
+
+    def test_cuit(self):
+        comprobante = Comprobante.objects.get(pk=1)
+        comprobante.nro_cuit = "30-38905723-7"
+        comprobante.save()
+        comprobante = Comprobante.objects.get(pk=1)
+        assert comprobante.tipo_id_afip == ID_DOCUMENTO_AFIP_TIPO_CUIT
+

--- a/estudio/models.py
+++ b/estudio/models.py
@@ -109,16 +109,12 @@ class Estudio(models.Model):
         else:
             return Decimal("0.25")
 
-    def get_importe_total(self):
-        # TODO: escribir unit tests para este metodo, no se esta usando por ahora.
-        if self.fecha_cobro:
-            # TODO: ver bien como se calcula el total en caso de estar cobrado.
-            # hago raise por el momento, no tengo tiempo de verlo ahora
-            raise NotImplementedError
+    def get_importe_total_facturado(self):
         return Decimal(self.importe_estudio).quantize(Decimal('.01'), ROUND_UP) - \
                Decimal(self.diferencia_paciente).quantize(Decimal('.01'), ROUND_UP) + \
-               self.arancel_anestesia + Decimal(self.pension).quantize(Decimal('.01'), ROUND_UP) + \
-               self.importe_medicacion
+               Decimal(self.arancel_anestesia).quantize(Decimal('.01'), ROUND_UP) + \
+               Decimal(self.pension).quantize(Decimal('.01'), ROUND_UP) + \
+               Decimal(self.importe_medicacion).quantize(Decimal('.01'), ROUND_UP)
 
     def get_total_medicacion(self):
         """

--- a/estudio/serializers.py
+++ b/estudio/serializers.py
@@ -71,7 +71,10 @@ class EstudioDePresetancionRetrieveSerializer(serializers.ModelSerializer):
 
     def get_importe_estudio(self, estudio):
         try:
-            arancel = ArancelObraSocial.objects.get(obra_social_id=estudio.obra_social_id, practica_id=estudio.practica_id).precio
+            if estudio.importe_estudio != Decimal('0.00'):
+                arancel = estudio.importe_estudio
+            else:
+                arancel = ArancelObraSocial.objects.get(obra_social_id=estudio.obra_social_id, practica_id=estudio.practica_id).precio
         except ArancelObraSocial.DoesNotExist:
             arancel = Decimal('0.00')
         return arancel

--- a/estudio/serializers.py
+++ b/estudio/serializers.py
@@ -56,7 +56,7 @@ class EstudioCreateUpdateSerializer(serializers.ModelSerializer):
         fields = (u'id',u'fecha', u'paciente', u'practica', u'obra_social', u'medico',
             u'medico_solicitante', u'anestesista', u'motivo', u'informe', u'sucursal')
 
-class EstudioDePresetancionRetrieveSerializer(serializers.ModelSerializer):
+class EstudioSinPresentarSerializer(serializers.ModelSerializer):
     paciente = PacienteSerializer()
     practica = PracticaSerializer()
     medico = MedicoSerializer()
@@ -71,10 +71,7 @@ class EstudioDePresetancionRetrieveSerializer(serializers.ModelSerializer):
 
     def get_importe_estudio(self, estudio):
         try:
-            if estudio.importe_estudio != Decimal('0.00'):
-                arancel = estudio.importe_estudio
-            else:
-                arancel = ArancelObraSocial.objects.get(obra_social_id=estudio.obra_social_id, practica_id=estudio.practica_id).precio
+            arancel = ArancelObraSocial.objects.get(obra_social_id=estudio.obra_social_id, practica_id=estudio.practica_id).precio
         except ArancelObraSocial.DoesNotExist:
             arancel = Decimal('0.00')
         return arancel
@@ -82,6 +79,10 @@ class EstudioDePresetancionRetrieveSerializer(serializers.ModelSerializer):
     def get_importe_medicacion(self, estudio):
         return estudio.get_total_medicacion()
 
+
+class EstudioDePresentacionRetrieveSerializer(EstudioSinPresentarSerializer):
+   def get_importe_estudio(self, estudio):
+        return estudio.importe_estudio
 
 class MedicacionSerializer(serializers.HyperlinkedModelSerializer):
     medicamento = MedicamentoSerializer()

--- a/fixtures/estudios.json
+++ b/fixtures/estudios.json
@@ -248,5 +248,14 @@
         "estudio": 9,
         "importe": "1.00"
     }
+},
+{
+    "model": "estudio.medicacion",
+    "pk": 3,
+    "fields": {
+        "medicamento": 2,
+        "estudio": 12,
+        "importe": "1.00"
+    }
 }
 ]

--- a/obra_social/views.py
+++ b/obra_social/views.py
@@ -4,7 +4,7 @@ from rest_framework import filters, viewsets, generics
 from rest_framework.decorators import detail_route
 from estudio.models import Estudio, ID_SUCURSAL_CEDIR
 from obra_social.models import ObraSocial
-from estudio.serializers import EstudioDePresetancionRetrieveSerializer
+from estudio.serializers import EstudioSinPresentarSerializer
 from obra_social.serializers import ObraSocialSerializer
 
 class ObraSocialNombreFilterBackend(filters.BaseFilterBackend):
@@ -41,7 +41,7 @@ class ObraSocialViewSet(viewsets.ModelViewSet):
             sucursal=sucursal,
         ).order_by('fecha', 'id')
         try:
-            response = JsonResponse(EstudioDePresetancionRetrieveSerializer(estudios, many=True).data, status=200, safe=False)
+            response = JsonResponse(EstudioSinPresentarSerializer(estudios, many=True).data, status=200, safe=False)
         except Exception as ex:
             response = JsonResponse({'error': ex.message}, status=500)
         return response

--- a/obra_social/views.py
+++ b/obra_social/views.py
@@ -2,7 +2,7 @@ import simplejson
 from django.http import JsonResponse
 from rest_framework import filters, viewsets, generics
 from rest_framework.decorators import detail_route
-from estudio.models import Estudio
+from estudio.models import Estudio, ID_SUCURSAL_CEDIR
 from obra_social.models import ObraSocial
 from estudio.serializers import EstudioDePresetancionRetrieveSerializer
 from obra_social.serializers import ObraSocialSerializer
@@ -32,7 +32,7 @@ class ObraSocialViewSet(viewsets.ModelViewSet):
         # El legacy le pone id=0
         # Como aca presentacion es FK (como corresponde), esto esta bastante DUDOSO por ahora y complica despues el serializer
         # Cuando el legacy arregle eso (o lo tiremos) esto deberia cambiar para buscar presentacion=None
-        sucursal = request.query_params.get(u'sucursal', default='Cedir')
+        sucursal = request.query_params.get(u'sucursal', default=ID_SUCURSAL_CEDIR)
         estudios = Estudio.objects.filter(
             obra_social__pk=pk,
             es_pago_contra_factura=0,

--- a/presentacion/serializers.py
+++ b/presentacion/serializers.py
@@ -64,7 +64,6 @@ class PresentacionCreateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         estudios_data = validated_data['estudios']
-        estudios = Estudio.objects.filter(id__in=[e["id"] for e in estudios_data])
         del validated_data['estudios']
         validated_data['comprobante'] = None
         validated_data['iva'] = 0
@@ -77,10 +76,11 @@ class PresentacionCreateSerializer(serializers.ModelSerializer):
             estudio.importe_estudio = estudio_data.get("importe_estudio", estudio.importe_estudio)
             estudio.pension = estudio_data.get("pension", estudio.pension)
             estudio.diferencia_paciente = estudio_data.get("diferencia_paciente", estudio.diferencia_paciente)
-            estudio.importe_medicacion = estudio_data.get("medicacion", estudio.importe_medicacion)
+            estudio.importe_medicacion = estudio.get_total_medicacion() + estudio.get_total_material_especifico()
             estudio.arancel_anestesia = estudio_data.get("arancel_anestesia", estudio.arancel_anestesia)
             estudio.save()
-        presentacion.total_facturado = sum([e.get_importe_total() for e in estudios])
+        estudios = Estudio.objects.filter(id__in=[e["id"] for e in estudios_data])
+        presentacion.total_facturado = sum([e.get_importe_total_facturado() for e in estudios])
         presentacion.save()
         return presentacion
 
@@ -122,7 +122,6 @@ class PresentacionUpdateSerializer(serializers.ModelSerializer):
         instance.periodo = validated_data.get("periodo", instance.periodo)
         instance.fecha = validated_data.get("fecha", instance.fecha)
         estudios_data = validated_data['estudios']
-        estudios = Estudio.objects.filter(id__in=[e["id"] for e in estudios_data])
         for estudio in instance.estudios.all():
             estudio.presentacion_id = 0
             estudio.save()
@@ -133,10 +132,11 @@ class PresentacionUpdateSerializer(serializers.ModelSerializer):
             estudio.importe_estudio = estudio_data.get("importe_estudio", estudio.importe_estudio)
             estudio.pension = estudio_data.get("pension", estudio.pension)
             estudio.diferencia_paciente = estudio_data.get("diferencia_paciente", estudio.diferencia_paciente)
-            estudio.importe_medicacion = estudio_data.get("medicacion", estudio.importe_medicacion)
+            estudio.importe_medicacion = estudio.get_total_medicacion() + estudio.get_total_material_especifico()
             estudio.arancel_anestesia = estudio_data.get("arancel_anestesia", estudio.arancel_anestesia)
             estudio.save()
-        instance.total_facturado = sum([e.get_importe_total() for e in estudios])
+        estudios = Estudio.objects.filter(id__in=[e["id"] for e in estudios_data])
+        instance.total_facturado = sum([e.get_importe_total_facturado() for e in estudios])
         instance.save()
         return instance
     class Meta:

--- a/presentacion/serializers.py
+++ b/presentacion/serializers.py
@@ -66,12 +66,10 @@ class PresentacionCreateSerializer(serializers.ModelSerializer):
         estudios_data = validated_data['estudios']
         estudios = Estudio.objects.filter(id__in=[e["id"] for e in estudios_data])
         del validated_data['estudios']
-        presentacion = Presentacion.objects.create(
-            comprobante=None,
-            iva=0,
-            estado=Presentacion.ABIERTO,
-            **validated_data
-        )
+        validated_data['comprobante'] = None
+        validated_data['iva'] = 0
+        validated_data['estado'] = Presentacion.ABIERTO
+        presentacion = Presentacion.objects.create(**validated_data)
         for estudio_data in estudios_data:
             estudio = Estudio.objects.get(pk=estudio_data['id'])
             estudio.presentacion = presentacion

--- a/presentacion/serializers.py
+++ b/presentacion/serializers.py
@@ -8,7 +8,7 @@ from presentacion.models import PagoPresentacion, Presentacion
 from obra_social.models import ObraSocial
 from comprobante.models import Comprobante, TipoComprobante, Gravado, LineaDeComprobante, ID_TIPO_COMPROBANTE_LIQUIDACION
 from estudio.models import Estudio
-from estudio.serializers import EstudioDePresetancionRetrieveSerializer
+from estudio.serializers import EstudioDePresentacionRetrieveSerializer
 from obra_social.serializers import ObraSocialSerializer
 from comprobante.serializers import ComprobanteSerializer
 
@@ -31,7 +31,7 @@ class PresentacionRetrieveSerializer(serializers.ModelSerializer):
     obra_social = ObraSocialSerializer()
     comprobante = ComprobanteSerializer()
     estado = EstadoField()
-    estudios = EstudioDePresetancionRetrieveSerializer(many=True)
+    estudios = EstudioDePresentacionRetrieveSerializer(many=True)
 
     class Meta:
         model = Presentacion

--- a/presentacion/tests.py
+++ b/presentacion/tests.py
@@ -328,7 +328,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ],
@@ -345,6 +344,7 @@ class TestCrearPresentacion(TestCase):
         assert estudio.obra_social_id == 1
         assert estudio.presentacion_id == 0
         assert estudio.importe_estudio == Decimal("10000.00")
+        assert estudio.get_total_medicacion() + estudio.get_total_material_especifico() == 2
         datos = {
             "obra_social_id": 1,
             "periodo": "SEPTIEMBRE 2019",
@@ -357,7 +357,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ],
@@ -367,6 +366,11 @@ class TestCrearPresentacion(TestCase):
         estudio = Estudio.objects.get(pk=9)
         assert estudio.presentacion_id != 0
         assert estudio.importe_estudio == 5
+        assert estudio.importe_medicacion == 2
+        assert estudio.diferencia_paciente == 1
+        assert estudio.pension == 1
+        assert estudio.arancel_anestesia == 1
+        assert estudio.get_importe_total_facturado() == 8 # 9 - 1
 
     def test_crear_presentacion_con_estudio_ya_presentado_falla(self):
         estudio_ya_presentado = Estudio.objects.get(pk=1)
@@ -383,7 +387,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ],
@@ -408,7 +411,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ],
@@ -433,7 +435,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ],
@@ -444,6 +445,8 @@ class TestCrearPresentacion(TestCase):
         assert estudio.presentacion_id == response.data['id']
 
     def test_crear_presentacion_total_es_suma_importes_estudios(self):
+        estudio = Estudio.objects.get(pk=12)
+        assert estudio.get_total_medicacion() + estudio.get_total_material_especifico() == 1
         datos = {
             "obra_social_id": 1,
             "periodo": "perio3",
@@ -456,7 +459,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 1,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ]
@@ -465,7 +467,7 @@ class TestCrearPresentacion(TestCase):
         response = self.client.post('/api/presentacion/', data=json.dumps(datos),
                                 content_type='application/json')
         presentacion = Presentacion.objects.get(pk=response.data['id'])
-        assert presentacion.total_facturado == 3
+        assert presentacion.total_facturado == 3 # 4 - 1
 
     def test_crear_presentacion_falla_si_estudio_es_de_otra_sucursal(self):
         estudio = Estudio.objects.get(pk=9)
@@ -484,7 +486,6 @@ class TestCrearPresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ],
@@ -527,7 +528,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
                 {
@@ -536,7 +536,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ]
@@ -562,6 +561,7 @@ class TestUpdatePresentacion(TestCase):
         assert estudio.obra_social_id == 1
         assert estudio.presentacion_id == 0
         assert estudio.importe_estudio == Decimal("10000.00")
+        assert estudio.get_total_medicacion() + estudio.get_total_material_especifico() == 1
         datos = {
             "obra_social_id": 1,
             "periodo": "SEPTIEMBRE 2019",
@@ -573,7 +573,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
             ],
@@ -583,6 +582,11 @@ class TestUpdatePresentacion(TestCase):
         estudio = Estudio.objects.get(pk=12)
         assert estudio.presentacion_id != 0
         assert estudio.importe_estudio == 5
+        assert estudio.importe_medicacion == 1
+        assert estudio.diferencia_paciente == 1
+        assert estudio.pension == 1
+        assert estudio.arancel_anestesia == 1
+        assert estudio.get_importe_total_facturado() == 7 # 8 - 1
 
     def test_update_presentacion_cerrada_falla(self):
         # Tomamos una presentacion con dos estudios, quitamos uno y agregamos otro.
@@ -599,7 +603,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
                 {
@@ -608,7 +611,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ]
@@ -630,7 +632,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
                 {
@@ -639,7 +640,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ]
@@ -665,7 +665,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
             ]
@@ -687,7 +686,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
             ]
@@ -697,6 +695,8 @@ class TestUpdatePresentacion(TestCase):
         assert response.status_code == 400
 
     def test_update_presentacion_total_es_suma_importes_estudios(self):
+        estudio = Estudio.objects.get(pk=12)
+        assert estudio.get_total_medicacion() + estudio.get_total_material_especifico() == 1
         datos = {
             "periodo": "perio3",
             "fecha": "2019-12-25",
@@ -707,7 +707,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 1,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 }
             ]
@@ -716,7 +715,7 @@ class TestUpdatePresentacion(TestCase):
         response = self.client.patch('/api/presentacion/8/', data=json.dumps(datos),
                                 content_type='application/json')
         presentacion = Presentacion.objects.get(pk=8)
-        assert presentacion.total_facturado == 3
+        assert presentacion.total_facturado == 3 # 4 - 1
 
     def test_update_presentacion_con_estudio_de_otra_sucursal_falla(self):
         estudio = Estudio.objects.get(pk=12)
@@ -735,7 +734,6 @@ class TestUpdatePresentacion(TestCase):
                     "importe_estudio": 5,
                     "pension": 1,
                     "diferencia_paciente": 1,
-                    "medicacion": 1,
                     "arancel_anestesia": 1
                 },
             ]

--- a/presentacion/tests.py
+++ b/presentacion/tests.py
@@ -289,11 +289,19 @@ class TestEstudiosDePresentacion(TestCase):
 
     def test_get_estudios_de_presentacion(self):
         presentacion = Presentacion.objects.get(pk=1)
-        n_estudios = len(presentacion.estudios.all())
-        assert n_estudios != 0
+        estudio = Estudio.objects.get(pk=1)
+        assert estudio.presentacion_id == 1
+        estudio.importe_estudio = 4
+        estudio.pension = 6
+        estudio.arancel_anestesia = 7
+        estudio.save()
         response = self.client.get('/api/presentacion/1/estudios/')
         estudios_response = json.loads(response.content)
-        assert len(estudios_response) == n_estudios
+        estudio_data = [e for e in estudios_response if e["id"] == 1][0]
+        assert Decimal(estudio_data["importe_estudio"]) == 4
+        assert Decimal(estudio_data["pension"]) == 6
+        assert Decimal(estudio_data["arancel_anestesia"]) == 7
+
 
 class TestCrearPresentacion(TestCase):
     fixtures = ['pacientes.json', 'medicos.json', 'practicas.json', 'obras_sociales.json',

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -86,7 +86,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
         sucursal = request
         estudios = presentacion.estudios.all().order_by('fecha', 'id')
         try:
-            response = JsonResponse(EstudioDePresetancionRetrieveSerializer(estudios, many=True).data, safe=False)
+            response = JsonResponse(EstudioDePresentacionRetrieveSerializer(estudios, many=True).data, safe=False)
         except Exception as ex:
             response = JsonResponse({'error': unicode(ex)}, status=500)
         return response

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -60,7 +60,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
 
             response = HttpResponse(csv_string, content_type='text/plain')
         except Exception as ex:
-            response = HttpResponse(simplejson.dumps({'error': str(ex)}), status=500, content_type='application/json')
+            response = HttpResponse(simplejson.dumps({'error': unicode(ex)}), status=500, content_type='application/json')
 
         return response
 
@@ -77,7 +77,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
 
             response = HttpResponse(csv_string[:-1], content_type='text/plain')
         except Exception as ex:
-            response = HttpResponse(simplejson.dumps({'error': str(ex)}), status=500, content_type='application/json')
+            response = HttpResponse(simplejson.dumps({'error': unicode(ex)}), status=500, content_type='application/json')
         return response
 
     @detail_route(methods=['get'])
@@ -88,7 +88,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
         try:
             response = JsonResponse(EstudioDePresetancionRetrieveSerializer(estudios, many=True).data, safe=False)
         except Exception as ex:
-            response = JsonResponse({'error': str(ex)}, status=500)
+            response = JsonResponse({'error': unicode(ex)}, status=500)
         return response
 
     @detail_route(methods=['patch'])
@@ -120,9 +120,9 @@ class PresentacionViewSet(viewsets.ModelViewSet):
             response = JsonResponse(PresentacionSerializer(presentacion).data, safe=False)
 
         except ValidationError as ex:
-            response = JsonResponse({'error': str(ex)}, status=400)
+            response = JsonResponse({'error': unicode(ex)}, status=400)
         except Exception as ex:
-            response = JsonResponse({'error': str(ex)}, status=500)
+            response = JsonResponse({'error': unicode(ex)}, status=500)
         return response
 
     @detail_route(methods=['patch'])
@@ -140,7 +140,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
             presentacion.save()
             return JsonResponse(PresentacionSerializer(presentacion).data, safe=False)
         except Exception as ex:
-            return JsonResponse({'error': str(ex)}, status=500)
+            return JsonResponse({'error': unicode(ex)}, status=500)
 
     @detail_route(methods=['patch'])
     def cobrar(self, request, pk=None):
@@ -162,7 +162,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
         except Estudio.DoesNotExist:
                 response = JsonResponse({'error': "No existe un estudio con esa id"}, status=400)
         except ValidationError as ex:
-            response = JsonResponse({'error': str(ex)}, status=400)
+            response = JsonResponse({'error': unicode(ex)}, status=400)
         except Exception as ex:
-            response = JsonResponse({'error': str(ex)}, status=500)
+            response = JsonResponse({'error': unicode(ex)}, status=500)
         return response

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -105,7 +105,7 @@ class PresentacionViewSet(viewsets.ModelViewSet):
             comprobante_data["neto"] = presentacion.total_facturado
             comprobante_data["nombre_cliente"] = obra_social.nombre
             comprobante_data["domicilio_cliente"] = obra_social.direccion
-            comprobante_data["nro_cuit"] = obra_social.nro_cuit
+            comprobante_data["nro_cuit"] = obra_social.nro_cuit.replace('-', '')
             comprobante_data["condicion_fiscal"] = obra_social.condicion_fiscal
             comprobante_data["concepto"] = "FACTURACION CORRESPONDIENTE A " + presentacion.periodo
             comprobante_data["fecha_emision"] = presentacion.fecha

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -25,7 +25,7 @@ from comprobante.serializers import crear_comprobante_serializer_factory
 class PresentacionViewSet(viewsets.ModelViewSet):
     queryset = Presentacion.objects.all().order_by('-fecha')
     serializer_class = PresentacionSerializer
-    filter_fields = ('obra_social',)
+    filter_fields = ('obra_social', 'sucursal')
     pagination_class = StandardResultsSetPagination
     page_size = 50
 

--- a/presentacion/views.py
+++ b/presentacion/views.py
@@ -15,7 +15,7 @@ from presentacion.obra_social_custom_code.osde_presentacion_digital import \
     OsdeRowEstudio, OsdeRowMedicacion, OsdeRowPension, OsdeRowMaterialEspecifico
 from presentacion.obra_social_custom_code.amr_presentacion_digital import AmrRowEstudio
 from estudio.models import Estudio
-from estudio.serializers import EstudioDePresetancionRetrieveSerializer
+from estudio.serializers import EstudioDePresentacionRetrieveSerializer
 from obra_social.models import ObraSocial
 from comprobante.models import Comprobante, LineaDeComprobante, Gravado, TipoComprobante, \
     ID_TIPO_COMPROBANTE_LIQUIDACION


### PR DESCRIPTION
# Mas ajustes antes del release Presentacion
Abro esta PR con algunos ajustes que tuve que hacer cuando probe la PR de David antes de subirla a staging.
## Cambios hasta ahora

- estudios_sin_presentar tenia mal el default
- el serializer de comprobante no cuantificaba correctamente los datos y
la afip se quejaba de los decimales al /cerrar
- fix de un exploit (? que permitia que el frontend sobreescriba parametros en el create. Particularmente molesto con campos que antes eran parte del endpoint pero los sacamos.
- fix de un bug contable: /presentacion/:id/estudios mostraba de importe el arancel de obra social incluso cuando ya se habia guardado un valor de importe_estudio.
- Se diferencian serializers de /estudios y /estudios_sin_presentar
- Se pasan los quantize a afip.py
- Se arregla logica de como se suma la medicacion de los estudios

## Estado de esta PR

Habria que mergearla y hacer los proximos arreglos en otra PR.