### PR TITLE
informacion_extra en para Facturacion

### DIFF
--- a/paciente/serializers.py
+++ b/paciente/serializers.py
@@ -5,13 +5,13 @@ from django.conf import settings
 
 
 class PacienteSerializer(serializers.HyperlinkedModelSerializer):
-    
+
     class Meta:
         model = Paciente
-        fields = (u'id', u'dni', u'nombre', u'apellido', u'_edad')
+        fields = (u'id', u'dni', u'nombre', u'apellido', u'_edad', 'nroAfiliado', 'informacion_extra')
 
 class PacienteFormSerializer(serializers.ModelSerializer):
-    
+
     class Meta:
         model = Paciente
         fields = ['id', 'dni', 'nombre', 'apellido', 'domicilio', 'telefono', 'sexo', 'fechaNacimiento', 'nroAfiliado', 'informacion_extra', 'email']


### PR DESCRIPTION
# Informacion_extra en Paciente para facturacion

## Cambios en esta PR

Se agregan los campos de nroAfiliado e informacion_extra en el
serializer de pacientes, por ser informacion necesaria para facturar. Esto infla un poco las otras requests que pidan pacientes y no usen en esa info, pero no me parece tan grave y no le veo sentido a:

- Usar el otro serializer, que tiene logica propia del formulario, ni
- Hacer uno nuevo solo para esto.

Posiblemente tenga que durante la semana meter algun cambio mas en esta PR.

## Migrations en esta PR

No hay.

## Estado de la PR

Si les parece bien la solucion, lo paso a staging para que David pueda incorporar la info en la tabla. Igual, antes de mergear a master quiero ver si no tengo que agregar mas cambios.