### PR TITLE
Primeros pasos para migrar a Python 3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,13 @@
+# Título de tu PR
+
+## Cambios en esta PR
+
+Qué cambios incorporas?
+
+## Estado de la PR
+
+Está mergeable? Qué falta?
+
+## Migrations
+
+Hay migrations? Se fakean o se corren normal?

--- a/comprobante/tests_afip.py
+++ b/comprobante/tests_afip.py
@@ -109,7 +109,7 @@ class TestAfipAPI(TestCase):
         assert mock_afip.call_count == 2
         afip.emitir_comprobante(comprobante, [])
         assert mock_afip.call_count == 3
-        mock_wsfev1.return_value.CAESolicitar.assert_is_called()
+        mock_wsfev1.return_value.CAESolicitar.assert_called()
 
     @patch("comprobante.afip._Afip.autenticar")
     @patch("comprobante.afip.WSAA")
@@ -136,7 +136,7 @@ class TestAfipAPI(TestCase):
         assert mock_afip.call_count == 2
         afip.emitir_comprobante(comprobante, [])
         assert mock_afip.call_count == 2
-        mock_wsfev1.return_value.CAESolicitar.assert_is_called()
+        mock_wsfev1.return_value.CAESolicitar.assert_called()
 
     @patch("comprobante.afip.WSAA")
     @patch("comprobante.afip.WSFEv1")

--- a/estudio/tests.py
+++ b/estudio/tests.py
@@ -49,7 +49,8 @@ class CrearEstudioTest(TestCase):
         response = self.client.post('/api/estudio/', self.estudio_data)
 
         self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.content, '{"practica":["This field is required."]}')
+        content = json.loads(response.content)
+        assert content["practica"] == ["This field is required."]
 
     def test_create_estudio_sucess_crea_un_log(self):
         ct = ContentType.objects.get_for_model(Estudio)

--- a/estudio/views.py
+++ b/estudio/views.py
@@ -198,7 +198,7 @@ class EstudioViewSet(viewsets.ModelViewSet):
             add_log_entry(estudio, self.request.user, CHANGE, 'PAGO CONTRA FACTURA')
             response = JsonResponse({}, status=status.HTTP_200_OK)
         except ValidationError as ex:
-            response = JsonResponse({'error': ex.message}, status=status.HTTP_400_BAD_REQUEST)
+            response = JsonResponse({'error': str(ex)}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as ex:
             response = JsonResponse({'error': str(ex)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/obra_social/views.py
+++ b/obra_social/views.py
@@ -43,5 +43,5 @@ class ObraSocialViewSet(viewsets.ModelViewSet):
         try:
             response = JsonResponse(EstudioSinPresentarSerializer(estudios, many=True).data, status=200, safe=False)
         except Exception as ex:
-            response = JsonResponse({'error': ex.message}, status=500)
+            response = JsonResponse({'error': str(ex)}, status=500)
         return response

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,7 +3,7 @@
 # reinstall pillow: pip install --no-cache-dir -I pillow
 Django==1.10.1
 Pillow==2.5.1
-simplejson==2.3.2
+simplejson==3.17.2
 psycopg2==2.8.3
 #bootstrap-admin  # https://github.com/douglasmiranda/django-admin-bootstrap
 ConcurrentLogHandler==0.9.1
@@ -18,7 +18,7 @@ httplib2==0.9.2
 git+https://github.com/reingart/pyafipws.git
 
 # testing or dev tools (TODO: should go on a different file)
-mock==1.0.1                    # Mocking and patching library for testing
+mock==3.0.5                    # Mocking and patching library for testing
 pylint
 pylint-django==0.11.1
 xlrd

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 Django==1.10.1
 Pillow==2.5.1
 psycopg2==2.8.3
-simplejson==2.3.2
+simplejson==3.17.2
 #bootstrap-admin  # https://github.com/douglasmiranda/django-admin-bootstrap
 ConcurrentLogHandler==0.9.1
 reportlab==3.3.0
@@ -18,7 +18,7 @@ httplib2==0.9.2
 git+https://github.com/reingart/pyafipws.git
 
 # testing or dev tools (TODO: should go on a different file)
-mock==1.0.1                    # Mocking and patching library for testing
+mock==3.0.5                    # Mocking and patching library for testing
 pylint
 pylint-django==0.11.1
 xlrd # Tool informe contadora

--- a/security/encryption.py
+++ b/security/encryption.py
@@ -4,7 +4,7 @@ import random
 
 
 def encode(key):
-    random_letter = random.choice(string.letters)
+    random_letter = random.choice(string.ascii_letters)
     return random_letter + base64.urlsafe_b64encode(str(key))
 
 


### PR DESCRIPTION
# Primeros pasos para migrar a Python 3

## Cambios en esta PR

Los siguientes cambios son retrocompatibles con Python 2 pero necesarios para pasar a Python 3. El objetivo de esta PR es agrupar los cambios manuales y verificables en code review antes de hacer los cambios automaticos con 2to3, que genera un MONTON de cambios y estos quedarían perdidos.

Notese que son para migrar a Python 3, pero manteniendo la misma version de django. Pasar a django 2 o 3 implica breaking changes algo molestos que quisiera separar.

- string.letters estaba deprecado y debe ser reemplazado por
ascii_letters
- assert_is_called no existe. En Python 2 es un falso positivo porque
mock lo crea. En Python 3 es error. El correcto es assert_caled.
- ex.message deja de existir (o de usarse en django, no se) y hay que usar (como en casi todo el code
base) str(ex)
- Se upgradean algunas librerias que no corren en Python 3.

También agrego una tempalte de PR porque vi que Dani adoptó este formato.

## Estado de la PR

WiP: Faltan un par mas para solucionar tests que fallan. Todavia no se si las soluciones van a ser retrocompatibles.

## Migrations

No hay.
