### PR TITLE
Cambio de algoritmo de uuid

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -1,4 +1,5 @@
-import uuid
+import shortuuid
+
 from django.contrib.admin.models import LogEntry
 from django.contrib.contenttypes.models import ContentType
 
@@ -8,8 +9,7 @@ def generate_uuid():
     Return a random UUID as a string with dashes removed
     Deberia reemplazar el encode(id) ya que es muy corto.
     """
-    return str(uuid.uuid1()).replace('-', '')
-
+    return shortuuid.uuid()[:8]
 
 def add_log_entry(obj, user, mode, message):
     ct = ContentType.objects.get_for_model(type(obj))

--- a/estudio/tests.py
+++ b/estudio/tests.py
@@ -43,7 +43,7 @@ class CrearEstudioTest(TestCase):
         self.assertEqual(estudio.medico_id, self.estudio_data.get('medico'))
         self.assertIsNotNone(estudio.public_id)
         self.assertIsNot(estudio.public_id, '')
-        self.assertEqual(len(estudio.public_id), 32)
+        self.assertEqual(len(estudio.public_id), 8)
 
     def test_create_estudio_returns_error_if_practica_is_empty(self):
         self.estudio_data.pop('practica')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ reportlab==3.3.0
 django-filter==1.1.0
 djangorestframework==3.4.6
 django-cors-headers==1.3.1
+shortuuid==1.0.1
 
 # AFIP
 httplib2==0.9.2

--- a/turno/views.py
+++ b/turno/views.py
@@ -340,8 +340,6 @@ def anunciar(request, id_turno):
             estudio.anestesista_id = 1
             estudio.set_create_defaults()
             estudio.save()
-            estudio.public_id = encode(estudio.id)  # actualiza a un public_id mas corto, para facilidad al paciente.
-            estudio.save()
 
             # log estudio
             add_log_entry(estudio, request.user, ADDITION, 'CREA (desde turnos)')


### PR DESCRIPTION
# Cambio de algoritmo de uuid

## Cambios en esta PR

Se pasa a shortuuid, que garantiza que se puede truncar con baja posibilidad de colisiones.
Analicé otras alternativas pero todas quedaban muy largos los IDs o truncarlos generaba muchas colisiones.

También modifique turno.views para que no pise la uuid default.

## Estado de la PR

Esta mergeable.

## Migrations

No hay migrations, pero como hay un requirement nuevo, hay que hacer `pip install -r requirements.txt`