### PR TITLE
Crear comprobantes 2

### DIFF
--- a/comprobante/serializers.py
+++ b/comprobante/serializers.py
@@ -3,6 +3,7 @@ from decimal import Decimal, ROUND_UP
 from datetime import date
 from rest_framework import serializers
 from rest_framework.serializers import ValidationError
+from collections import OrderedDict
 
 from comprobante.models import Comprobante, LineaDeComprobante, TipoComprobante, Gravado, ID_TIPO_COMPROBANTE_LIQUIDACION
 from settings import CEDIR_PTO_VENTA, BRUNETTI_PTO_VENTA
@@ -233,9 +234,27 @@ class CrearComprobanteAFIPSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError('"responsable" debe ser "Cedir" o Brunetti"')
         return value
 
-    def validate(self, data):
-        for linea in data['lineas']:
+    def validate_lineas(self, value):
+        for linea in value:
             linea.is_valid(raise_exception=True)
+        return value
+
+    def validate(self, data):
+        errors = OrderedDict()
+        
+        for field in data:
+            validate_method = getattr(self, 'validate_' + field, None)
+            try:
+                if validate_method:
+                    validate_method(data[field])
+            except ValidationError as e:
+                errors[field] = e.detail
+            except Exception as e:
+                errors[field] = str(e)
+        
+        if errors:
+            raise ValidationError(errors)
+
         return data
 
     def create(self, validated_data):

--- a/comprobante/serializers.py
+++ b/comprobante/serializers.py
@@ -55,7 +55,7 @@ class ComprobanteSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Comprobante
         fields = ('id', 'nombre_cliente', 'sub_tipo', 'numero', 'nro_terminal', 'total_facturado', 'total_cobrado',
-                  'fecha_emision', 'tipo_comprobante', 'gravado', 'lineas')
+                  'fecha_emision', 'tipo_comprobante', 'gravado', 'lineas', 'cae')
 
 
 class ComprobanteSmallSerializer(serializers.ModelSerializer):

--- a/comprobante/tests.py
+++ b/comprobante/tests.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from decimal import Decimal
 from mock import patch
 from comprobante.afip import AfipError
-from .models import LineaDeComprobante, Gravado
+from .models import LineaDeComprobante, Gravado, TipoComprobante
 from .serializers import CrearComprobanteAFIPSerializer, CrearLineaDeComprobanteSerializer
 
 class TestCrearLineaSerializer(TestCase):
@@ -167,4 +167,17 @@ class TestCrearComprobanteSerializer(TestCase):
         comprobante_serializer = CrearComprobanteAFIPSerializer(data=comprobante_data)
 
         assert not comprobante_serializer.is_valid()
-        assert 'gravado_id' in comprobante_serializer.errors
+        assert 'lineas' in comprobante_serializer.errors
+        assert 'gravado_id' in comprobante_serializer.errors['lineas']
+
+    @patch('comprobante.serializers.Afip')
+    def test_crear_comprobante_error_si_tipo_comprobante_id_no_existe(self, afip_mock):
+        afip = afip_mock()
+        comprobante_data = {**self.comprobante_data}
+        comprobante_data['tipo_comprobante_id'] = TipoComprobante.objects.last().id + 1
+        comprobante_data['lineas'] = self.lineas_data
+
+        comprobante_serializer = CrearComprobanteAFIPSerializer(data=comprobante_data)
+
+        assert not comprobante_serializer.is_valid()
+        assert 'tipo_comprobante_id' in comprobante_serializer.errors

--- a/comprobante/tests.py
+++ b/comprobante/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from decimal import Decimal
 from mock import patch
+from comprobante.afip import AfipError
 from .models import LineaDeComprobante, Gravado
 from .serializers import CrearComprobanteAFIPSerializer, CrearLineaDeComprobanteSerializer
 
@@ -82,7 +83,7 @@ class TestCrearComprobanteSerializer(TestCase):
             ]
         self.comprobante_data = {
             'tipo_comprobante_id': 1,
-            'sub_tipo': 'B',
+            'sub_tipo': 'A',
             'responsable': 'Cedir',
             'gravado_id': '1',
             'nombre_cliente': 'Homero',
@@ -91,7 +92,7 @@ class TestCrearComprobanteSerializer(TestCase):
             'condicion_fiscal': 'RESPONSABLE INSCRIPTO',
         }
     
-    @patch('comprobante.comprobante_asociado.Afip')
+    @patch('comprobante.serializers.Afip')
     def test_comprobante_afip_serializer_funciona_si_no_envian_lineas(self, afip_mock):
         afip = afip_mock()
         comprobante_data = {**self.comprobante_data}
@@ -109,6 +110,7 @@ class TestCrearComprobanteSerializer(TestCase):
 
         total = neto + neto * iva / Decimal(100)
 
+        afip.emitir_comprobante.assert_called_once()
         assert comprobante.total_facturado == total
         assert comprobante.tipo_comprobante.id == comprobante_data['tipo_comprobante_id']
         assert comprobante.sub_tipo == comprobante_data['sub_tipo']
@@ -120,7 +122,7 @@ class TestCrearComprobanteSerializer(TestCase):
         assert linea.sub_total == total
         assert linea.concepto == comprobante_data['concepto']
 
-    @patch('comprobante.comprobante_asociado.Afip')
+    @patch('comprobante.serializers.Afip')
     def test_comprobante_afip_serializer_funciona_si_envian_lineas(self, afip_mock):
         afip = afip_mock()
         comprobante_data = {**self.comprobante_data}
@@ -138,6 +140,7 @@ class TestCrearComprobanteSerializer(TestCase):
 
         total = neto + neto * iva / Decimal(100)
 
+        afip.emitir_comprobante.assert_called_once()
         assert comprobante.total_facturado == total
         assert comprobante.tipo_comprobante.id == comprobante_data['tipo_comprobante_id']
         assert comprobante.sub_tipo == comprobante_data['sub_tipo']
@@ -154,7 +157,7 @@ class TestCrearComprobanteSerializer(TestCase):
             assert lineas[i].iva == linea_data['importe_neto'] * gravado.porcentaje / Decimal(100)
             assert lineas[i].concepto == linea_data['concepto']
 
-    @patch('comprobante.comprobante_asociado.Afip')
+    @patch('comprobante.serializers.Afip')
     def test_crear_comprobante_error_si_gravado_id_no_existe(self, afip_mock):
         afip = afip_mock()
         comprobante_data = {**self.comprobante_data}

--- a/comprobante/views.py
+++ b/comprobante/views.py
@@ -117,7 +117,7 @@ class ComprobanteViewSet(viewsets.ModelViewSet):
                 raise serializers.ValidationError(comprobante_serializer.errors)
 
             comprobante = comprobante_serializer.save()
-            response = JsonResponse({'comprobante_id': comprobante.id}, status=status.HTTP_201_CREATED)
+            response = JsonResponse({'cae': comprobante.cae}, status=status.HTTP_201_CREATED)
         except serializers.ValidationError as ex:
             response = JsonResponse({'error': str(ex)}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as ex:

--- a/obra_social/serializers.py
+++ b/obra_social/serializers.py
@@ -6,7 +6,7 @@ class ObraSocialSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = ObraSocial
-        fields = ('id', 'nombre', )
+        fields = ('id', 'nombre', 'nro_cuit', 'direccion', 'condicion_fiscal', )
 
 class ObraSocialPensionSerializer(serializers.HyperlinkedModelSerializer):
 


### PR DESCRIPTION
# Crear comprobantes 2

## Cambios en esta PR

 - Se agrega al serializer de obra social datos que faltaban enviar
 - Se devuelve el cae despues de crear un comprobante
 - Se corrige un error que hacia que no se ejecuten los validators de comprobante

## Estado de la PR

Lista

## Migrations

No hay