### PR TITLE
Fix importe medicacion

### DIFF
--- a/estudio/serializers.py
+++ b/estudio/serializers.py
@@ -102,10 +102,19 @@ class EstudioDePresentacionRetrieveSerializer(EstudioSinPresentarSerializer):
         return str(estudio.get_total_medicacion())
 
 class EstudioDePresentacionImprimirSerializer(EstudioDePresentacionRetrieveSerializer):
-    medicacion = MedicamentoSerializer(many=True)
+    medicacion = serializers.SerializerMethodField()
 
     class Meta:
         model = Estudio
         fields = ('id', 'fecha', 'nro_de_orden', 'paciente', 'practica',
             'medico', 'importe_estudio', 'pension', 'diferencia_paciente',
             'importe_medicacion', 'arancel_anestesia', 'medicacion')
+
+    def get_medicacion(self, estudio):
+        medicacion = []
+        for medicamento in Medicacion.objects.filter(estudio=estudio):
+            medicacion_serializer = MedicacionSerializer(medicamento).data
+            medicamento = medicacion_serializer['medicamento']
+            medicamento['importe'] = medicacion_serializer['importe'] #Se actualiza el importe del medicamento con el importe con el que salio en el momento
+            medicacion += [medicamento]
+        return medicacion


### PR DESCRIPTION
# Fix importe medicacion

## Contexto

En la impresion de presentacion se estaba utilizando el importe de los medicamentos actuales. Esto es un problema debido a que los importes de la facturacion no se correspondian con los importes de la impresion, pudiendo llevar a problemas con las obras sociales. En esta pr se utiliza el importe de la medicacion del momento en el que se creo la presentacion

## Cambios en esta PR
 
 - Se actualiza el serializer de medicacion por uno personalizado

## Estado de la PR

Lista

## Migrations

No hay