### PR TITLE
Modificar arancel obra social

### DIFF
--- a/obra_social/admin.py
+++ b/obra_social/admin.py
@@ -21,4 +21,13 @@ class ArancelObraSocialAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
+    def changeform_view(self, request, object_id=None, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        
+        if not self.has_add_permission(request):
+            extra_context['show_save_and_continue'] = False
+            extra_context['show_save'] = False
+
+        return super(ArancelObraSocialAdmin, self).changeform_view(request, object_id, extra_context=extra_context)
+
 admin.site.register(ArancelObraSocial, ArancelObraSocialAdmin)


### PR DESCRIPTION
# Modificar arancel obra social

## Cambios en esta PR

Me pidieron una forma de hacer que las personas puedan ver los datos de arancel obra social pero que no puedan modificarlos. En esta pr hice que las personas que poseen el permiso de editar, pero no el de agregar no puedan editar el arancel, ya que no van a tener los botones.

## Estado de la PR

Me falta la confirmacion de Mariana, pero ya estaria.

## Migrations

No hay