### PR TITLE
Script reset montos acumulados

### DIFF
--- a/scripts/reset_montos_acumulados.py
+++ b/scripts/reset_montos_acumulados.py
@@ -1,0 +1,27 @@
+# Set directory
+import os
+import sys
+import inspect
+currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parentdir = os.path.dirname(currentdir)
+sys.path.insert(0, parentdir)
+
+# Init Django
+import django
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+django.setup()
+
+# Reset MontosAcumulados
+from caja.models import MovimientoCaja, MontoAcumulado, ID_CONSULTORIO_1, ID_CONSULTORIO_2, ID_GENERAL
+
+def reset_montos():
+    for id in (ID_CONSULTORIO_1, ID_CONSULTORIO_2):
+        monto = MontoAcumulado.objects.get(tipo__id=id)
+        monto.monto_acumulado = 0
+        monto.save()
+    
+    monto = MontoAcumulado.objects.get(tipo__id=ID_GENERAL)
+    monto.monto_acumulado = MovimientoCaja.objects.last().monto_acumulado
+    monto.save()
+
+reset_montos()


### PR DESCRIPTION
# Script reset montos acumulados

## Cambios en esta PR

 - Se crea un script para resetear los montos acumulados

## Estado de la PR

Lista.

## Migrations

No hay

## Pasos extra

Debido a que para correr el script necesitamos modulos de django, hay que iniciar el entorno antes de correr. Tambien, es un script que tiene que correr automaticamente todos los dias, por lo que hay que agregarlo a crontab.

Un ejemplo de crontab que funcionaria es:
`30 20 * * * bash; source /home/user/cedir/ENV/bin/activate; python /home/user/cedir/web/scripts/reset_montos_acumulados.py; deactivate; exit`
