### PR TITLE
Ordenar en caja y otros cambios

### DIFF
--- a/caja/serializers.py
+++ b/caja/serializers.py
@@ -47,6 +47,7 @@ class MovimientoCajaFullSerializer(serializers.ModelSerializer):
     medico = MedicoSerializer()
     user = serializers.SerializerMethodField()
     hora = serializers.SerializerMethodField()
+    fecha = serializers.SerializerMethodField()
 
     class Meta:
         model = MovimientoCaja
@@ -57,6 +58,9 @@ class MovimientoCajaFullSerializer(serializers.ModelSerializer):
     
     def get_hora(self, obj):
         return str(obj.hora)[:5]
+
+    def get_fecha(self, obj):
+        return obj.fecha.strftime("%d/%m/%Y")
 
 class MovimientoCajaCamposVariablesSerializer(serializers.Serializer):
     tipo_id = serializers.IntegerField(required=True)

--- a/caja/tests.py
+++ b/caja/tests.py
@@ -312,10 +312,10 @@ class ListadoCajaTest(TestCase):
         results = json.loads(response.content).get('results')
 
         for result in results:
-            fecha = list(map(int, result['fecha'].split('-')))
-            assert fecha[0] == 2019
+            fecha = list(map(int, result['fecha'].split('/')))
+            assert fecha[2] == 2019
             assert fecha[1] == 2
-            assert 1 <= fecha[2] <= 8
+            assert 1 <= fecha[0] <= 8
 
     def test_filtro_tipo_movimiento_funciona(self):
         parametro_busqueda = 'General'

--- a/caja/views.py
+++ b/caja/views.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-name-in-module, import-error
+from django.db import reset_queries
 from rest_framework import viewsets, status, serializers
 from caja.serializers import MovimientoCajaFullSerializer, MovimientoCajaImprimirSerializer, MovimientoCajaCreateSerializer, MovimientoCajaUpdateSerializer
 from caja.models import MovimientoCaja, MontoAcumulado, ID_CONSULTORIO_1, ID_CONSULTORIO_2, ID_GENERAL
@@ -19,7 +20,7 @@ from decimal import Decimal
 from django.http import HttpResponse, JsonResponse
 
 from rest_framework.serializers import ValidationError
-from rest_framework.filters import BaseFilterBackend
+from rest_framework.filters import BaseFilterBackend, OrderingFilter
 from rest_framework.decorators import list_route
 
 class CajaMovimientoFilterBackend(BaseFilterBackend):
@@ -63,10 +64,11 @@ class CajaEstudioFilterBackend(BaseFilterBackend):
 
 class MovimientoCajaViewSet(viewsets.ModelViewSet):
     model = MovimientoCaja
-    queryset = MovimientoCaja.objects.all().order_by('-id')
+    queryset = MovimientoCaja.objects.all().order_by('id')
     serializer_class = MovimientoCajaFullSerializer
     pagination_class = StandardResultsSetPagination
-    filter_backends = (CajaMovimientoFilterBackend, CajaEstudioFilterBackend)
+    filter_backends = (CajaMovimientoFilterBackend, CajaEstudioFilterBackend, OrderingFilter)
+    ordering_fields = '__all__'
 
     def create(self, request):
         try:
@@ -109,7 +111,7 @@ class MovimientoCajaViewSet(viewsets.ModelViewSet):
     @list_route(methods=['GET'])
     def imprimir(self, request):
         try:
-            movimientos = self.filter_queryset(MovimientoCaja.objects.all())
+            movimientos = self.filter_queryset(MovimientoCaja.objects.all().order_by('id'))
 
             if len(movimientos) == 0:
                 raise ValidationError('Debe seleccionarse una fecha donde hayan movimientos')

--- a/caja/views.py
+++ b/caja/views.py
@@ -1,5 +1,4 @@
 # pylint: disable=no-name-in-module, import-error
-from django.db import reset_queries
 from rest_framework import viewsets, status, serializers
 from caja.serializers import MovimientoCajaFullSerializer, MovimientoCajaImprimirSerializer, MovimientoCajaCreateSerializer, MovimientoCajaUpdateSerializer
 from caja.models import MovimientoCaja, MontoAcumulado, ID_CONSULTORIO_1, ID_CONSULTORIO_2, ID_GENERAL


### PR DESCRIPTION
# Ordenar en caja y otros cambios

## Cambios en esta PR

 - Se agregan filtros para poder ordenar por campo en caja
 - Se ordena de forma descendente el imprimir caja
 - Se cambia en el serializer de caja para enviar la fecha formateada

## Estado de la PR

Lista

## Migrations

No hay