### PR TITLE
Presentaciones cobradas pasan información extra

### DIFF
--- a/presentacion/serializers.py
+++ b/presentacion/serializers.py
@@ -31,9 +31,21 @@ class PresentacionRetrieveSerializer(serializers.ModelSerializer):
     comprobante = ComprobanteSerializer()
     estado = EstadoField()
     estudios = EstudioDePresentacionRetrieveSerializer(many=True)
+    fecha_cobro = serializers.SerializerMethodField()
+    nro_recibo = serializers.SerializerMethodField()
 
     class Meta:
         model = Presentacion
+
+    def get_fecha_cobro(self, obj):
+        if(obj.estado == Presentacion.COBRADO):
+            return PagoPresentacion.objects.get(presentacion=obj).fecha
+        return None
+
+    def get_nro_recibo(self, obj):
+        if(obj.estado == Presentacion.COBRADO):
+            return PagoPresentacion.objects.get(presentacion=obj).nro_recibo
+        return None
 
 class PresentacionImprimirSerializer(serializers.ModelSerializer):
     obra_social = ObraSocialSerializer()

--- a/presentacion/tests.py
+++ b/presentacion/tests.py
@@ -126,7 +126,7 @@ class TestRetrievePresentacion(TestCase):
 
     def test_presentaciones_cobradas_info(self):
         response = self.client.get('/api/presentacion/2/')
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
 
         results = json.loads(response.content)
         pago = PagoPresentacion.objects.get(presentacion__id=2)
@@ -136,7 +136,7 @@ class TestRetrievePresentacion(TestCase):
 
     def test_presentaciones_no_cobradas_tienen_None_en_algunos_campos(self):
         response = self.client.get('/api/presentacion/1/')
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
 
         results = json.loads(response.content)
 

--- a/presentacion/tests.py
+++ b/presentacion/tests.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.db.models import Q
 from rest_framework import status
 
-from presentacion.models import Presentacion
+from presentacion.models import PagoPresentacion, Presentacion
 from presentacion.obra_social_custom_code.amr_presentacion_digital import AmrRowBase
 from presentacion.obra_social_custom_code.osde_presentacion_digital import OsdeRowBase
 from obra_social.models import ObraSocial
@@ -123,6 +123,25 @@ class TestRetrievePresentacion(TestCase):
             assert presentaciones[i].comprobante.numero == results[i]['comprobante']['numero']
             assert comprobante_actual <= results[i]['comprobante']['numero']
             comprobante_actual = results[i]['comprobante']['numero']
+
+    def test_presentaciones_cobradas_info(self):
+        response = self.client.get('/api/presentacion/2/')
+        assert response.status_code == 200
+
+        results = json.loads(response.content)
+        pago = PagoPresentacion.objects.get(presentacion__id=2)
+
+        assert results['fecha_cobro'] == str(pago.fecha)
+        assert results['nro_recibo'] == str(pago.nro_recibo)
+
+    def test_presentaciones_no_cobradas_tienen_None_en_algunos_campos(self):
+        response = self.client.get('/api/presentacion/1/')
+        assert response.status_code == 200
+
+        results = json.loads(response.content)
+
+        assert results['fecha_cobro'] == None
+        assert results['nro_recibo'] == None
 
 class TestCobrarPresentacion(TestCase):
     fixtures = ['pacientes.json', 'medicos.json', 'practicas.json', 'obras_sociales.json',


### PR DESCRIPTION
# Presentaciones cobradas pasan información extra

## Cambios en esta PR
La api de get presentaciones cuando piden una cobrada, se devuelve ademas el nro de recibo y la fecha de cobro.

## Estado de la PR
Lista.

## Migrations
No hay